### PR TITLE
feat: glossarist-style Localization + SourceUrl models

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -84,3 +84,56 @@ actions:
     date_effective: 2019-10-17
     message: resolves to submit ISO 9735-11...
 ----
+
+== Multilingual support
+
+The model supports multilingual resolution sets using the
+glossarist-style `localizations[]` pattern. Each `Resolution` carries
+its language-agnostic admin fields (identifier, doi, urn, agendaItem,
+dates, etc.) plus a `localizations[]` array with one entry per
+language.
+
+Each `Localization` declares its `languageCode` (ISO 639-3 three-letter
+code) and `script` (ISO 15924 four-letter code), then carries the
+monolingual title, subject, message, considerations, actions, and
+approvals.
+
+See `models/localization.lutaml` and `models/source_url.lutaml` for
+the model definitions.
+
+=== Sample multilingual YAML
+
+[source,yaml]
+----
+resolutions:
+  - identifier: CIML/2025/44
+    doi: 10.63493/resolutions/ciml202544
+    urn: urn:oiml:doc:ciml:resolution:2025-44
+    agendaItem: "16.2"
+    dates:
+      - { start: '2025-10-13', kind: decision }
+    localizations:
+      - languageCode: eng
+        script: Latn
+        title: Decision on the renewal of the contract of Mr Anthony Donnellan
+        subject: CIML
+        actions:
+          - type: decides
+            message: |
+              The Committee decides to renew the contract of
+              Mr Anthony Donnellan as BIML Director.
+      - languageCode: fra
+        script: Latn
+        title: Décision sur le renouvellement du contrat de M. Anthony Donnellan
+        subject: CIML
+        actions:
+          - type: decides
+            message: |
+              Le Comité décide de renouveler le contrat de
+              M. Anthony Donnellan en tant que Directeur du BIML.
+----
+
+=== SourceUrl
+
+A per-language source-PDF reference used in
+`ResolutionMetadata.sourceUrls[]`. See `models/source_url.lutaml`.

--- a/models/localization.lutaml
+++ b/models/localization.lutaml
@@ -1,0 +1,11 @@
+class Localization {
+  languageCode: Iso639ThreeCharCode
+  script: Iso15924Code
+  title: String
+  subject: String
+  message: String
+  considering: String
+  considerations: Consideration[0..*]
+  approvals: Approval[0..*]
+  actions: Action[0..*]
+}

--- a/models/resolution.lutaml
+++ b/models/resolution.lutaml
@@ -1,12 +1,13 @@
 class Resolution {
-  subject: SubjectBody
-  title: String
-  type: ResolutionType
   identifier: StructuredIdentifier[1..*]
-  meeting: MeetingIdentifier
+  type: ResolutionType
+  doi: String
+  urn: String
+  agendaItem: String
   dates: ResolutionDate[1..*]
-  considerations: Consideration[1..*]
-  actions: Action[1..*]
-  approvals: Approval[1..*]
-  agendaItem: AgendaItemId
+  categories: String[0..*]
+  meeting: MeetingIdentifier
+  relations: ResolutionRelation[0..*]
+  urls: Url[0..*]
+  localizations: Localization[1..*]
 }

--- a/models/resolution_metadata.lutaml
+++ b/models/resolution_metadata.lutaml
@@ -1,5 +1,9 @@
 class ResolutionMetadata {
   date: DateTime
   title: String
+  titleLocalized: Localization[0..*]
   source: String
+  sourceUrls: SourceUrl[0..*]
+  city: String
+  countryCode: String
 }

--- a/models/source_url.lutaml
+++ b/models/source_url.lutaml
@@ -1,0 +1,5 @@
+class SourceUrl {
+  ref: String
+  format: String
+  languageCode: Iso639ThreeCharCode
+}


### PR DESCRIPTION
## Summary

Mirrors the Ruby gem's `localizations[]` pattern in the LutaML model files, in lockstep with metanorma/edoxen#7.

## New model files

- `models/localization.lutaml` — declares the `Localization` class with `languageCode` (`Iso639ThreeCharCode`), `script` (`Iso15924Code`), `title`, `subject`, `message`, `considering`, `considerations[]`, `actions[]`, `approvals[]`.
- `models/source_url.lutaml` — declares `SourceUrl` with `ref`, `format`, `languageCode`.

## Updated model files

- `models/resolution.lutaml` — keeps `identifier`, `type`, `doi`, `urn`, `agendaItem`, `dates`, `categories`, `meeting`, `relations`, `urls`; adds `localizations[1..*]`.
- `models/resolution_metadata.lutaml` — extended with `titleLocalized[]`, `sourceUrls[]`, `city`, `countryCode`.

## Docs

README.adoc gets a "Multilingual support" section with a sample bilingual YAML and a pointer to the new lutaml files.

## Companion PR

- metanorma/edoxen#7 — Ruby gem + JSON Schema.
