### PR TITLE
docs: rewrite README to match canonical LUTAML + Ruby gem conventions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,6 +10,12 @@ The Edoxen information models aim to unify those data elements in
 a common framework, allowing interoperability between and creation
 of references to resolutions and decisions.
 
+This repository holds the *canonical* LutaML UML definition of the
+model. The Ruby gem that implements it lives at
+https://github.com/metanorma/edoxen[metanorma/edoxen] and mirrors
+the LutaML files 1:1 — attribute declarations, enum values, and
+field shapes.
+
 
 == Applicability
 
@@ -27,17 +33,43 @@ number of bodies, including:
 
 == Information model
 
-The information models are in the https://github.com/lutaml/lutaml[LutaML UML]
-format.
+The information models are in the
+https://github.com/lutaml/lutaml[LutaML UML] format.
 
-See the `models/` directory.
+See the `models/` directory. One `.lutaml` file per concept:
+
+[cols="1,3"]
+|===
+| File | Concept
+
+| `resolution_collection.lutaml`   | Top-level container (`ResolutionCollection`).
+| `resolution_metadata.lutaml`     | Collection-level metadata (`ResolutionMetadata`).
+| `resolution.lutaml`              | A single formal `Resolution`.
+| `localization.lutaml`            | A monolingual rendering of a Resolution (glossarist-style).
+| `structured_identifier.lutaml`   | `prefix + number` identifier; a Resolution carries 1..*.
+| `meeting_identifier.lutaml`      | Meeting venue + date.
+| `resolution_date.lutaml`         | Date with semantic kind (adoption / drafted / discussed).
+| `resolution_relation.lutaml`     | Directed relation between two resolutions.
+| `action.lutaml`, `consideration.lutaml`, `approval.lutaml` | Per-localization sub-structures.
+| `url.lutaml`, `source_url.lutaml` | URLs — generic and per-language source PDF.
+| `*_type.lutaml`, `approval_degree.lutaml` | Closed value sets (enums).
+|===
 
 
 == YAML representation
 
-=== Resolution collection
+=== Wire-name convention
 
-The YAML representation of the data model is as follows.
+The LutaML files use `camelCase` for attribute names (`agendaItem`,
+`languageCode`, `dateEffective`). That is *notation*. The YAML wire
+form is `snake_case` (`agenda_item`, `language_code`,
+`date_effective`) — matching Ruby and YAML convention.
+
+The Ruby gem's `schema_enum_sync_spec.rb` and
+`schema_model_sync_spec.rb` enforce that the gem's `schema/edoxen.yaml`
+matches the LutaML definition value-for-value.
+
+=== Resolution collection
 
 [source,yaml]
 ----
@@ -45,58 +77,86 @@ metadata:
   title: Resolutions of the 38th plenary meeting of ISO/TC 154
   date: 2019-10-17
   source: ISO/TC 154 Secretariat
+  city: LUX
+  country_code: LU
+  source_urls:
+    - ref: https://www.iso.org/committee/45318/x/category.html
+      format: html
+      language_code: eng
 resolutions:
-  - category: Resolutions related to JWG 1
-    dates: 2019/10/17
-    ...
+  - identifier:
+      - prefix: ISO
+        number: "2019-01"
+    type: decision
+    # ... see "Resolution (single)" below
 ----
 
 === Resolution (single)
 
 [source,yaml]
 ----
-category: Resolutions related to JWG 1
+identifier:
+  - prefix: ISO
+    number: "2019-01"
+type: decision
+categories:
+  - Resolutions related to JWG 1
 dates:
-  - 2019-10-17
-subject: ISO/TC 154
-title: "Adoption of NWIP ballot for ISO/PWI 9735-11 “Electronic data..."
-identifier: 2019-01
-considerations:
-  - type: considering
-    date_effective: 2019-10-17
-    message: considering the voting result ...
-
-  - type: considering
-    date_effective: 2019-10-17
-    message: considering the importance of ...
-
-  - type: considering
-    date_effective: 2019-10-17
-    message: considering the request from JWG1...
-
-approvals:
-  - type: affirmative
-    degree: unanimous
-    message: The resolution was taken by unanimity.
-
-actions:
-  - type: resolves
-    date_effective: 2019-10-17
-    message: resolves to submit ISO 9735-11...
+  - date: 2019-10-17
+    type: discussed
+agenda_item: "11.2"
+meeting:
+  venue: University of Luxembourg
+  date: 2019-10-17
+localizations:
+  - language_code: eng
+    script: Latn
+    title: Adoption of NWIP ballot for ISO/PWI 9735-11
+    subject: ISO/TC 154 Processes, data elements and documents in commerce, industry and administration
+    considerations:
+      - type: considering
+        date_effective:
+          date: 2019-10-17
+          type: adoption
+        message: considering the voting result of NWIP ...
+      - type: considering
+        date_effective:
+          date: 2019-10-17
+          type: adoption
+        message: considering the importance of interoperability ...
+    approvals:
+      - type: affirmative
+        degree: unanimous
+        date:
+          date: 2019-10-17
+          type: adoption
+        message: The resolution was taken by unanimity.
+    actions:
+      - type: resolves
+        date_effective:
+          date: 2019-10-17
+          type: adoption
+        message: resolves to submit ISO 9735-11 for NWIP ballot again by end of this year.
 ----
+
+Every translatable field lives inside a `localizations[]` entry.
+Language-agnostic admin fields (`identifier`, `doi`, `urn`,
+`agenda_item`, `dates`, `categories`, `meeting`, `relations`, `urls`)
+live on the parent `Resolution`.
+
 
 == Multilingual support
 
 The model supports multilingual resolution sets using the
 glossarist-style `localizations[]` pattern. Each `Resolution` carries
-its language-agnostic admin fields (identifier, doi, urn, agendaItem,
-dates, etc.) plus a `localizations[]` array with one entry per
-language.
+its language-agnostic admin fields (`identifier`, `doi`, `urn`,
+`agenda_item`, `dates`, etc.) plus a `localizations[]` array with one
+entry per language.
 
-Each `Localization` declares its `languageCode` (ISO 639-3 three-letter
-code) and `script` (ISO 15924 four-letter code), then carries the
-monolingual title, subject, message, considerations, actions, and
-approvals.
+Each `Localization` declares its `language_code` (ISO 639-3
+three-letter code) and `script` (ISO 15924 four-letter code), then
+carries the monolingual `title`, `subject`, `message`, `considering`,
+`considerations`, `actions`, and `approvals`.
 
 See `models/localization.lutaml` and `models/source_url.lutaml` for
 the model definitions.
@@ -105,29 +165,57 @@ the model definitions.
 
 [source,yaml]
 ----
+metadata:
+  title: 56th CIML meeting (2025) — Resolutions
+  date: 2025-10-13
+  source: BIML Secretariat
+  title_localized:
+    - language_code: eng
+      script: Latn
+      title: 56th CIML meeting (2025) — Resolutions
+    - language_code: fra
+      script: Latn
+      title: 56e réunion du CIML (2025) — Résolutions
+  source_urls:
+    - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
+      format: pdf
+      language_code: eng
+    - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
+      format: pdf
+      language_code: fra
 resolutions:
-  - identifier: CIML/2025/44
+  - identifier:
+      - prefix: CIML
+        number: "2025-44"
+    type: decision
     doi: 10.63493/resolutions/ciml202544
     urn: urn:oiml:doc:ciml:resolution:2025-44
-    agendaItem: "16.2"
+    agenda_item: "16.2"
     dates:
-      - { start: '2025-10-13', kind: decision }
+      - date: 2025-10-13
+        type: discussed
     localizations:
-      - languageCode: eng
+      - language_code: eng
         script: Latn
         title: Decision on the renewal of the contract of Mr Anthony Donnellan
         subject: CIML
         actions:
           - type: decides
+            date_effective:
+              date: 2025-10-13
+              type: adoption
             message: |
               The Committee decides to renew the contract of
               Mr Anthony Donnellan as BIML Director.
-      - languageCode: fra
+      - language_code: fra
         script: Latn
         title: Décision sur le renouvellement du contrat de M. Anthony Donnellan
         subject: CIML
         actions:
           - type: decides
+            date_effective:
+              date: 2025-10-13
+              type: adoption
             message: |
               Le Comité décide de renouveler le contrat de
               M. Anthony Donnellan en tant que Directeur du BIML.
@@ -136,4 +224,36 @@ resolutions:
 === SourceUrl
 
 A per-language source-PDF reference used in
-`ResolutionMetadata.sourceUrls[]`. See `models/source_url.lutaml`.
+`ResolutionMetadata.source_urls[]`. See `models/source_url.lutaml`.
+
+
+== Ruby implementation
+
+The Ruby gem at https://github.com/metanorma/edoxen[metanorma/edoxen]
+implements this model:
+
+* One Ruby class per LutaML class, attribute declarations mirror the
+  LutaML definitions 1:1.
+* `Edoxen::Enums` mirrors the LutaML enums; the schema's enum arrays
+  are kept in lockstep by the gem's `schema_enum_sync_spec.rb`.
+* `Edoxen::Resolution#in_language(code, fallback:)` and
+  `#primary_localization` provide the canonical lookup accessors
+  (English when available, else the first declared localization).
+* A JSON-Schema (`schema/edoxen.yaml`) enforces `additionalProperties:
+  false`, `required`, `enum`, and `pattern` constraints the Ruby model
+  is permissive about.
+* A Thor CLI (`edoxen validate`, `edoxen normalize`) wraps both layers.
+
+Install:
+
+[source,sh]
+----
+gem install edoxen
+----
+
+Validate against the canonical shape:
+
+[source,sh]
+----
+edoxen validate "resolutions/*.yaml"
+----


### PR DESCRIPTION
## Summary

The previous README had drifted from the canonical LUTAML model in several ways:

- **"Resolution (single)"** sample showed the long-obsolete flat shape with `title`, `subject`, `category` at the top level — those fields live inside `localizations[]` since the glossarist-style refactor.
- `identifier: 2019-01` was a scalar; canonical is `StructuredIdentifier[1..*]` (`{prefix, number}`).
- `dates: - 2019-10-17` was a bare date string array; canonical is `ResolutionDate[1..*]` (`{date, type}`).
- Multilingual sample used camelCase wire names (`languageCode`, `agendaItem`, `dateEffective`) — LUTAML uses camelCase as notation, but the YAML wire form is snake_case per Ruby / YAML convention.
- `{ start, kind }` shape for `ResolutionDate` was the pre-canonical form; canonical is `{ date, type }` with `type` ∈ `ResolutionDateType` (adoption / drafted / discussed).
- No cross-reference to the Ruby gem that implements this model.

## What changes

- **Wire-name convention** documented explicitly (camelCase notation, snake_case wire).
- All YAML samples use the canonical shape — matching what the Ruby gem's `schema/edoxen.yaml` enforces and what its fixture files (`ciml-56-44.yaml`, `cipm-111-2.yaml`, `isotc154-plenary-38.yaml`) look like in production.
- New **Information model** section lists every `.lutaml` file with a one-line concept description, so readers can navigate `models/` without grepping.
- New **Ruby implementation** section cross-references `metanorma/edoxen`, the schema-sync invariant, and the `Resolution#in_language` / `#primary_localization` lookup accessors.

## Test plan

- [x] No `.lutaml` model files changed.
- [x] YAML samples match the canonical model definition in `models/`.
- [x] YAML samples would pass the Ruby gem's `edoxen validate` (each shape is exercised by the gem's fixtures).
