### PR TITLE
feat(unlocode): canonical type for city field is UN/LOCODE

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -77,7 +77,7 @@ metadata:
   title: Resolutions of the 38th plenary meeting of ISO/TC 154
   date: 2019-10-17
   source: ISO/TC 154 Secretariat
-  city: LUX
+  city: LULUX
   country_code: LU
   source_urls:
     - ref: https://www.iso.org/committee/45318/x/category.html

--- a/models/resolution_metadata.lutaml
+++ b/models/resolution_metadata.lutaml
@@ -4,6 +4,6 @@ class ResolutionMetadata {
   titleLocalized: Localization[0..*]
   source: String
   sourceUrls: SourceUrl[0..*]
-  city: String
+  city: UnLocode  // UN/LOCODE, 5-char (ISO 3166-1 country + 3-char location)
   countryCode: String
 }


### PR DESCRIPTION
Update the canonical LUTAML to reflect that `ResolutionMetadata.city` is a UN/LOCODE, not a plain string.

## Changes

- `models/resolution_metadata.lutaml` — `city: UnLocode` (UN/LOCODE 5-char: ISO 3166-1 country + 3-char location) with a comment pointing to the standard.
- `README.adoc` sample YAML — `city: LULUX` instead of the IATA `LUX`.

Mirrors the Ruby gem's `schema/edoxen.yaml` pattern `^[A-Z]{2}[A-Z0-9]{3}$` landed in [edoxen PR #15](https://github.com/edoxen/edoxen/pull/15).

UN/LOCODE is UN-maintained; supersedes the airport-centric IATA city code.
