### PR TITLE
feat: complete the Meeting/Agenda/Minutes model

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -65,19 +65,25 @@ Resolutions, plus the agenda document that orders its business.
 | File | Concept
 
 | `meeting_collection.lutaml`, `meeting_collection_metadata.lutaml` | Top-level wrapper for many Meetings.
-| `meeting.lutaml`                 | A single Meeting (event).
+| `meeting.lutaml`                 | A single Meeting (event). Carries identity, time, venue, officers, agenda, schedule, deadlines, attendance, vote records, and minutes.
 | `meeting_localization.lutaml`    | Per-language content for a Meeting.
 | `meeting_relation.lutaml`        | Directed link between two Meetings.
 | `agenda.lutaml`                  | The business-order document of a Meeting.
-| `agenda_item.lutaml`             | One entry on an Agenda.
-| `schedule_item.lutaml`           | One entry in the timetable.
+| `agenda_item.lutaml`             | One entry on an Agenda (numbered/unnumbered/header/opening/closing).
+| `schedule_item.lutaml`           | One entry in the timetable. Carries `localizations[]` for per-language event/description.
+| `schedule_item_localization.lutaml` | Per-language content for a ScheduleItem (glossarist pattern: structural fields stay on ScheduleItem; per-language text lives here).
 | `deadline.lutaml`                | A time-bound requirement.
 | `date_range.lutaml`              | Start + end pair (for multi-day meetings).
 | `location.lutaml`                | Venue geography (name, address, geo coords).
 | `person.lutaml`                  | Identity + contact + affiliation.
 | `host_ref.lutaml`                | Typed reference to an organization.
 | `reference.lutaml`               | Generic document reference.
-| `meeting_type.lutaml`, `meeting_status.lutaml`, `agenda_status.lutaml`, `agenda_item_kind.lutaml`, `agenda_item_outcome.lutaml`, `host_type.lutaml`, `meeting_relation_type.lutaml`, `source_url_kind.lutaml` | Closed value sets for the Meeting side.
+| `attendance.lutaml`              | One record per person present at a Meeting (status, proxy_for, affiliation, notes).
+| `vote_record.lutaml`             | One vote by one person on one resolution at one meeting.
+| `minutes.lutaml`                 | The narrative record of a Meeting — running record of what was said, by whom, in what order, with what outcome. Distinct from Agenda (planned) and ResolutionCollection (decisions). One Minutes per language.
+| `minutes_section.lutaml`         | One section of Minutes, typically keyed by agenda-item number so consumers can join Minutes ↔ AgendaItem ↔ Resolution.
+| `subject_body.lutaml`            | Structured body for a Resolution's subject (committee / WG / project). Used when the subject is more than a plain string.
+| `meeting_type.lutaml`, `meeting_status.lutaml`, `agenda_status.lutaml`, `agenda_item_kind.lutaml`, `agenda_item_outcome.lutaml`, `host_type.lutaml`, `meeting_relation_type.lutaml`, `source_url_kind.lutaml`, `participation_status.lutaml`, `vote_type.lutaml` | Closed value sets for the Meeting side.
 |===
 
 A Meeting links to ResolutionCollection(s) by URN
@@ -85,6 +91,29 @@ A Meeting links to ResolutionCollection(s) by URN
 Meetings and Resolutions have different lifetimes — agendas exist
 weeks before a meeting, resolutions only after adoption — so they
 are kept as separate documents.
+
+=== The Meeting trinity: Agenda, Resolutions, Minutes
+
+A Meeting owns three distinct documents, each with its own lifetime
+and structure:
+
+[cols="1,4",options="header"]
+|===
+| Document | Concept
+| `Agenda` | The business order, drafted *before* the meeting. Items, opening_session, closing_session, source_doc.
+| `ResolutionCollection` | The formal decisions adopted *by* the meeting. Joined to the Meeting by URN (`metadata.meeting_urn`).
+| `Minutes` | The running narrative record of *what was said* at the meeting. Sections are typically keyed by agenda-item number so consumers can join Minutes ↔ AgendaItem ↔ Resolution.
+|===
+
+Plus three Meeting-side rosters:
+
+[cols="1,4",options="header"]
+|===
+| Roster | Concept
+| `attendance[]` | One `Attendance` record per person present (status, proxy_for, affiliation, notes). Mirrors `ParticipationStatus` (present / absent / apologies / observer / excused).
+| `vote_records[]` | One `VoteRecord` per (person × resolution). Carries `VoteType` (affirmative / negative / abstain / absent / not_applicable) plus affiliation and notes.
+| `minutes[]` | One `Minutes` document per language. Each carries `sections: MinutesSection[]` with Markdown narrative — the format the GLM-OCR pipeline emits.
+|===
 
 
 == YAML representation

--- a/models/attendance.lutaml
+++ b/models/attendance.lutaml
@@ -1,0 +1,7 @@
+class Attendance {
+  person: Person
+  status: ParticipationStatus
+  affiliation: String
+  proxy_for: Person
+  notes: String
+}

--- a/models/meeting.lutaml
+++ b/models/meeting.lutaml
@@ -30,6 +30,10 @@ class Meeting {
   schedule: ScheduleItem[0..*]
   deadlines: Deadline[0..*]
 
+  attendance: Attendance[0..*]
+  vote_records: VoteRecord[0..*]
+  minutes: Minutes[0..*]
+
   localizations: MeetingLocalization[0..*]
   relations: MeetingRelation[0..*]
   resolution_refs: String[0..*]

--- a/models/minutes.lutaml
+++ b/models/minutes.lutaml
@@ -1,0 +1,9 @@
+class Minutes {
+  identifier: StructuredIdentifier[0..*]
+  urn: String
+  language_code: Iso639ThreeCharCode
+  script: Iso15924Code
+  source_doc: String
+  source_pages: String
+  sections: MinutesSection[0..*]
+}

--- a/models/minutes_section.lutaml
+++ b/models/minutes_section.lutaml
@@ -1,0 +1,8 @@
+class MinutesSection {
+  number: String
+  title: String
+  narrative: String
+  page_start: Integer
+  page_end: Integer
+  references: Reference[0..*]
+}

--- a/models/participation_status.lutaml
+++ b/models/participation_status.lutaml
@@ -1,0 +1,7 @@
+enum ParticipationStatus {
+  present
+  absent
+  apologies
+  observer
+  excused
+}

--- a/models/schedule_item.lutaml
+++ b/models/schedule_item.lutaml
@@ -4,4 +4,5 @@ class ScheduleItem {
   event: String
   description: String
   room: String
+  localizations: ScheduleItemLocalization[0..*]
 }

--- a/models/schedule_item_localization.lutaml
+++ b/models/schedule_item_localization.lutaml
@@ -1,0 +1,6 @@
+class ScheduleItemLocalization {
+  language_code: Iso639ThreeCharCode
+  script: Iso15924Code
+  event: String
+  description: String
+}

--- a/models/subject_body.lutaml
+++ b/models/subject_body.lutaml
@@ -1,5 +1,15 @@
+// SubjectBody — the structured body of a Resolution's subject field.
+//
+// Used by Localization#subject when the subject is more than a plain
+// string: it identifies a committee, working group, project, or other
+// body the resolution is about. Carries the body's name, the
+// organization it belongs to, and an optional identifier so consumers
+// can join to external registries (ISO/TC 154 group slugs, OIML
+// committee IDs, etc.).
 class SubjectBody {
   name: String
-  address: String
-  // etc.
+  organization: String
+  identifier: String
+  role: String
+  kind: String
 }

--- a/models/vote_record.lutaml
+++ b/models/vote_record.lutaml
@@ -1,0 +1,7 @@
+class VoteRecord {
+  resolution_ref: String
+  person: Person
+  affiliation: String
+  vote: VoteType
+  notes: String
+}

--- a/models/vote_type.lutaml
+++ b/models/vote_type.lutaml
@@ -1,0 +1,7 @@
+enum VoteType {
+  affirmative
+  negative
+  abstain
+  absent
+  not_applicable
+}


### PR DESCRIPTION
Closes the gap the previous Meeting-model PR (#10) left: the canonical LUTAML now carries every type the Ruby gem already has on the Meeting side.

## New types (7 files)

- **`minutes.lutaml`** — the third leg of the Meeting trinity. Narrative record of a Meeting: what was said, by whom, in what order, with what outcome. Distinct from Agenda (planned) and ResolutionCollection (decisions). One Minutes per language.
- **`minutes_section.lutaml`** — one section of Minutes, typically keyed by agenda-item number so consumers can join Minutes ↔ AgendaItem ↔ Resolution.
- **`attendance.lutaml`** — one record per person present at a Meeting (status, proxy_for, affiliation, notes).
- **`vote_record.lutaml`** — one vote by one person on one resolution at one meeting (person, affiliation, vote enum, notes).
- **`schedule_item_localization.lutaml`** — per-language content for a ScheduleItem. Glossarist pattern: structural fields (date, time, room) stay on ScheduleItem; per-language text (event, description) lives here.
- **`participation_status.lutaml`** — enum (present / absent / apologies / observer / excused).
- **`vote_type.lutaml`** — enum (affirmative / negative / abstain / absent / not_applicable).

## Updated

- **`meeting.lutaml`** — add `attendance: Attendance[0..*]`, `vote_records: VoteRecord[0..*]`, `minutes: Minutes[0..*]`. Matches the Ruby `Edoxen::Meeting` class.
- **`schedule_item.lutaml`** — add `localizations: ScheduleItemLocalization[0..*]`. Matches `Edoxen::ScheduleItem`.
- **`subject_body.lutaml`** — replace `// etc.` stub with real fields (`name`, `organization`, `identifier`, `role`, `kind`). Models the structured body of a Resolution#subject when the subject is more than a plain string (identifies a committee / WG / project the resolution is about).

## README updates

- New types added to the file index table.
- New **"Meeting trinity: Agenda, Resolutions, Minutes"** subsection explaining the three documents a Meeting owns and their lifetimes.
- New table for the three rosters (`attendance[]`, `vote_records[]`, `minutes[]`) the Meeting carries.

## Canonical vs Ruby drift

After this PR, the LUTAML canonical and the Ruby gem (`edoxen` 0.7.1) agree value-for-value on every Meeting-side type. The schema ↔ Ruby enum-sync and shape-sync specs in the gem catch any future drift.
