### PR TITLE
feat(schema): add canonical JSON Schema files + worked examples

### DIFF
--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,20 @@
+# Edoxen Canonical Schemas
+
+This directory holds the canonical JSON Schema (Draft 7) files for
+Edoxen YAML data. These are the single source of truth — the Ruby gem
+at [edoxen/edoxen](https://github.com/edoxen/edoxen) mirrors them.
+
+## Files
+
+| File | Validates | Root type |
+|------|-----------|-----------|
+| `decision-collection.yaml` | Decision YAML files (was Resolution) | `DecisionCollection` or single `Decision` |
+| `meeting.yaml` | Meeting/Agenda YAML files | `Meeting` or `MeetingCollection` |
+
+## Examples
+
+The `examples/` directory has one fully-worked YAML per type:
+
+- `decision-example.yaml` — a CIML Decision (real fixture from the gem)
+- `meeting-example.yaml` — a CIML Meeting (from `samples/`)
+- `agenda-example.yaml` — just the `agenda` section of a Meeting

--- a/schema/decision-collection.yaml
+++ b/schema/decision-collection.yaml
@@ -1,0 +1,925 @@
+---
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://github.com/edoxen/edoxen-model/schema/decision-collection.yaml"
+title: "Edoxen Decision Collection Schema"
+description: |
+  Schema for validating Edoxen DecisionCollection YAML files.
+
+  Mirrors the canonical LutaML information model in
+  https://github.com/edoxen/edoxen-model/tree/main/models .
+
+  The enum constants declared under `$defs` are the authoritative wire
+  values. `spec/edoxen/schema_enum_sync_spec.rb` asserts each one is
+  character-for-character identical to the corresponding `Edoxen::Enums::*`
+  frozen array.
+
+  Trade-off: json_schemer's `valid_values` is not populated when an
+  `enum` is reached via `$ref`, so the validator's enum-violation
+  message degrades to "value ... is not one of: (see schema)". This
+  is documented in `Edoxen::SchemaValidator#format_message`.
+type: object
+additionalProperties: false
+
+properties:
+  metadata:
+    $ref: "#/$defs/DecisionMetadata"
+  decisions:
+    type: array
+    items:
+      $ref: "#/$defs/Decision"
+
+required:
+  - decisions
+
+$defs:
+
+  # ====================================================================
+  # Identifiers and references.
+  # ====================================================================
+
+  StructuredIdentifier:
+    type: object
+    description: "An identifier (prefix + number). A Decision carries 1..* of these."
+    additionalProperties: false
+    required: [prefix, number]
+    properties:
+      prefix:
+        type: string
+      number:
+        type: string
+
+  EntityRef:
+    type: object
+    description: |
+      Typed cross-reference between entities (v2.1, TODO.refactor/44).
+      Exactly one of `urn`, `identifier`, or `local_ref` should be set;
+      the gem's `EntityRef#valid?` enforces this in Ruby.
+    additionalProperties: false
+    properties:
+      urn:         { type: string }
+      identifier:  { $ref: "#/$defs/StructuredIdentifier" }
+      local_ref:   { type: string }
+      kind:        { type: string }
+      role:        { type: string }
+      note:        { type: string }
+
+  MeetingIdentifier:
+    type: object
+    description: "Identifies the meeting a Decision belongs to."
+    additionalProperties: false
+    properties:
+      venue:
+        type: string
+      date:
+        type: string
+        format: date
+
+  Url:
+    type: object
+    description: "URL with a kind (access / report) and an optional format hint."
+    additionalProperties: false
+    required: [kind, ref]
+    properties:
+      kind:
+        $ref: "#/$defs/UrlKind"
+      ref:
+        type: string
+      format:
+        type: string
+
+  DecisionRelation:
+    type: object
+    description: "Directed relation between two decisions identified by their StructuredIdentifier."
+    additionalProperties: false
+    required: [source, destination, type]
+    properties:
+      source:
+        $ref: "#/$defs/StructuredIdentifier"
+      destination:
+        $ref: "#/$defs/StructuredIdentifier"
+      type:
+        $ref: "#/$defs/DecisionRelationType"
+
+  # ====================================================================
+  # Date carriers.
+  # ====================================================================
+
+  DecisionDate:
+    type: object
+    description: "Date with semantic kind (adoption / drafted / discussed)."
+    additionalProperties: false
+    required: [date, type]
+    properties:
+      date:
+        type: string
+        format: date
+      type:
+        $ref: "#/$defs/DecisionDateType"
+
+  # ====================================================================
+  # Per-localization sub-structures.
+  # ====================================================================
+
+  Action:
+    type: object
+    description: "A verb + one effective date + human-readable message."
+    additionalProperties: false
+    required: [type, message, date_effective]
+    properties:
+      type:
+        $ref: "#/$defs/ActionType"
+      date_effective:
+        $ref: "#/$defs/DecisionDate"
+      message:
+        type: string
+
+  Approval:
+    type: object
+    description: "Approval record: vote type, consensus degree, date, message."
+    additionalProperties: false
+    required: [type, degree, date]
+    properties:
+      type:
+        $ref: "#/$defs/ApprovalType"
+      degree:
+        $ref: "#/$defs/ApprovalDegree"
+      date:
+        $ref: "#/$defs/DecisionDate"
+      message:
+        type: string
+
+  Consideration:
+    type: object
+    description: "The basis for a Decision: a verb + one effective date + reasoning."
+    additionalProperties: false
+    required: [type, message, date_effective]
+    properties:
+      type:
+        $ref: "#/$defs/ConsiderationType"
+      date_effective:
+        $ref: "#/$defs/DecisionDate"
+      message:
+        type: string
+
+  Localization:
+    type: object
+    description: |
+      A monolingual rendering of a Decision. Mirrors the glossarist
+      LocalizedConcept pattern: language-agnostic fields live on the
+      parent Decision; per-language content lives here.
+    additionalProperties: false
+    required: [language_code]
+    properties:
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      script:
+        type: string
+        pattern: "^[A-Z][a-z]{3}$"
+      title:        { type: string }
+      subject:      { type: string }
+      message:      { type: string }
+      considering:  { type: string }
+      considerations:
+        type: array
+        items:
+          $ref: "#/$defs/Consideration"
+      approvals:
+        type: array
+        items:
+          $ref: "#/$defs/Approval"
+      actions:
+        type: array
+        items:
+          $ref: "#/$defs/Action"
+
+  SourceUrl:
+    type: object
+    description: "Per-language canonical source URL (e.g. one PDF per language)."
+    additionalProperties: false
+    required: [ref]
+    properties:
+      ref:           { type: string }
+      format:        { type: string }
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      kind:
+        $ref: "#/$defs/SourceUrlKind"
+
+  # ====================================================================
+  # Top-level structures.
+  # ====================================================================
+
+  Decision:
+    type: object
+    description: |
+      A formal Decision. Language-agnostic admin fields live here;
+      every translatable field is wrapped inside `localizations[]`.
+    additionalProperties: false
+    required: [identifier, localizations]
+    properties:
+      identifier:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      kind:
+        $ref: "#/$defs/DecisionKind"
+      status:
+        $ref: "#/$defs/DecisionStatus"
+      body_type:          { type: string }
+      doi:               { type: string }
+      urn:               { type: string }
+      agenda_item:       { type: string }
+      dates:
+        type: array
+        items:
+          $ref: "#/$defs/DecisionDate"
+      categories:
+        type: array
+        items: { type: string }
+      meeting:
+        $ref: "#/$defs/MeetingIdentifier"
+      relations:
+        type: array
+        items:
+          $ref: "#/$defs/DecisionRelation"
+      urls:
+        type: array
+        items:
+          $ref: "#/$defs/Url"
+      brought_by_motions:
+        type: array
+        items: { type: string }
+      about_topics:
+        type: array
+        items: { type: string }
+      made_in_component: { type: string }
+      localizations:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/Localization"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  DecisionMetadata:
+    type: object
+    description: "Collection-level metadata (title, meeting date, source, source URLs, host venue)."
+    additionalProperties: false
+    properties:
+      title:        { type: string }
+      title_localized:
+        type: array
+        items:
+          $ref: "#/$defs/Localization"
+      date:
+        type: string
+        format: date
+      source:        { type: string }
+      source_urls:
+        type: array
+        items:
+          $ref: "#/$defs/SourceUrl"
+      city:
+        type: string
+        pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
+      country_code:
+        type: string
+        pattern: "^[A-Z]{2}$"
+      meeting_urn:   { type: string }
+      body_vocabulary:
+        type: array
+        items:
+          $ref: "#/$defs/BodyVocabularyEntry"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Body vocabulary (v2.1, TODO.refactor/46).
+  # ====================================================================
+
+  BodyVocabularyEntry:
+    type: object
+    description: |
+      One entry in a per-dataset body_vocabulary list. Maps a free-form
+      body_type to a short canonical value. SSOT for body_type ->
+      canonical_type resolution within the declaring collection.
+    additionalProperties: false
+    properties:
+      body_type:      { type: string }
+      canonical_type: { type: string }
+      definition:     { type: string }
+
+  # ====================================================================
+  # Procedural: Motion, Voting, VotingCounts.
+  # ====================================================================
+
+  Motion:
+    type: object
+    description: "A procedural act that brings a Decision."
+    additionalProperties: false
+    properties:
+      identifier:          { type: string }
+      urn:                 { type: string }
+      text:                { type: string }
+      mover:               { $ref: "#/$defs/Person" }
+      seconders:
+        type: array
+        items:
+          $ref: "#/$defs/Person"
+      status:              { $ref: "#/$defs/MotionStatus" }
+      introduced_at:          { type: string, format: date-time }
+      proposed_decision:      { type: string }
+      resulting_decision:     { type: string }
+      # Pilot EntityRef field (v2.1, TODO.refactor/44). Parallel to
+      # `resulting_decision`. Prefer in new code; bare String removed v3.0.
+      resulting_decision_ref: { $ref: "#/$defs/EntityRef" }
+      votings:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  VotingCounts:
+    type: object
+    description: "Tally for a Voting instance."
+    additionalProperties: false
+    properties:
+      ayes:         { type: integer }
+      noes:         { type: integer }
+      abstentions:  { type: integer }
+      absent:       { type: integer }
+
+  Voting:
+    type: object
+    description: "State machine for a single vote on a Motion."
+    additionalProperties: false
+    properties:
+      identifier:          { type: string }
+      urn:                 { type: string }
+      on_motion:           { type: string }
+      status:              { $ref: "#/$defs/VotingStatus" }
+      voting_method:       { $ref: "#/$defs/VotingMethod" }
+      called_by:           { $ref: "#/$defs/Person" }
+      called_at:           { type: string, format: date-time }
+      result_declared_at:  { type: string, format: date-time }
+      result:              { $ref: "#/$defs/VotingOutcome" }
+      counts:              { $ref: "#/$defs/VotingCounts" }
+      casting_vote:        { $ref: "#/$defs/VoteRecord" }
+      vote_records:
+        type: array
+        items:
+          $ref: "#/$defs/VoteRecord"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Topic and friends.
+  # ====================================================================
+
+  TopicDocument:
+    type: object
+    description: "Text-bearing document about a Topic."
+    additionalProperties: false
+    properties:
+      identifier:    { type: string }
+      title:         { type: string }
+      version:       { type: string }
+      status:        { type: string }
+      url:           { type: string }
+      format:        { type: string }
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  TopicAsset:
+    type: object
+    description: "Non-text resource about a Topic."
+    additionalProperties: false
+    properties:
+      identifier: { type: string }
+      title:      { type: string }
+      kind:       { type: string }
+      url:        { type: string }
+      format:     { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Topic:
+    type: object
+    description: "The subject of discussion at a Meeting."
+    additionalProperties: false
+    properties:
+      identifier:     { type: string }
+      urn:            { type: string }
+      title:          { type: string }
+      description:    { type: string }
+      status:         { $ref: "#/$defs/TopicStatus" }
+      resumption_of:  { type: string }
+      documents:
+        type: array
+        items:
+          $ref: "#/$defs/TopicDocument"
+      assets:
+        type: array
+        items:
+          $ref: "#/$defs/TopicAsset"
+      references:
+        type: array
+        items:
+          $ref: "#/$defs/Reference"
+      motions:
+        type: array
+        items: { type: string }
+      decisions:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Polymorphic Venue (flat wire shape; kind discriminates subtype).
+  # ====================================================================
+
+  Venue:
+    type: object
+    description: |
+      Polymorphic place where a Meeting happens. `kind` discriminates
+      physical vs virtual; all fields from both subtypes live here as
+      optional siblings. Validators (Edoxen::VenueValidator) enforce
+      that fields match `kind`.
+    additionalProperties: false
+    properties:
+      kind:              { $ref: "#/$defs/VenueKind" }
+      name:              { type: string }
+      label:             { type: string }
+      description:       { type: string }
+      capacity:          { type: integer }
+      url:               { type: string }
+
+      # Physical-venue fields.
+      unlocode:
+        type: string
+        pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
+      iata_code:
+        type: string
+        pattern: "^[A-Z]{3}$"
+      address:           { type: string }
+      city:              { type: string }
+      country_code:
+        type: string
+        pattern: "^[A-Z]{2}$"
+      lat:               { type: number }
+      lon:               { type: number }
+      building:          { type: string }
+      floor:             { type: string }
+      room:              { type: string }
+      access_notes:      { type: string }
+
+      # Virtual-venue fields.
+      uri:               { type: string }
+      features:
+        type: array
+        items:
+          $ref: "#/$defs/VirtualFeature"
+      passcode:                 { type: string }
+      meeting_id:               { type: string }
+      dial_in_numbers:
+        type: array
+        items: { type: string }
+      waiting_room:             { type: boolean }
+      registration_required:    { type: boolean }
+
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  PhysicalVenue:
+    description: "Marker — Venue with kind=physical. Wire shape is identical to Venue."
+    allOf:
+      - $ref: "#/$defs/Venue"
+
+  VirtualVenue:
+    description: "Marker — Venue with kind=virtual. Wire shape is identical to Venue."
+    allOf:
+      - $ref: "#/$defs/Venue"
+
+  # ====================================================================
+  # Recurrence (ISO 8601-2 §13 structured form).
+  # ====================================================================
+
+  RecurrenceByDay:
+    type: object
+    description: "BYDAY part of a recurrence. `ordinal` is null for 'every', +1 for first, -1 for last."
+    additionalProperties: false
+    properties:
+      ordinal: { type: integer }
+      weekday: { type: string }
+
+  Recurrence:
+    type: object
+    description: "Structured ISO 8601-2 §13 recurrence."
+    additionalProperties: false
+    properties:
+      freq:        { $ref: "#/$defs/RecurrenceFreq" }
+      interval:    { type: integer }
+      count:       { type: integer }
+      until:       { type: string, format: date-time }
+      by_day:
+        type: array
+        items:
+          $ref: "#/$defs/RecurrenceByDay"
+      by_month_day:
+        type: array
+        items: { type: integer }
+      by_month:
+        type: array
+        items: { type: integer }
+      by_week_no:
+        type: array
+        items: { type: integer }
+      by_year_day:
+        type: array
+        items: { type: integer }
+      by_hour:
+        type: array
+        items: { type: integer }
+      by_minute:
+        type: array
+        items: { type: integer }
+      by_second:
+        type: array
+        items: { type: integer }
+      by_set_pos:
+        type: array
+        items: { type: integer }
+      week_start: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Profile mechanism (ISO 8601-2 §15).
+  # ====================================================================
+
+  ExtensionAttribute:
+    type: object
+    description: |
+      One typed key/value pair within a MeetingExtension. Polymorphic on
+      value type so consumers don't re-parse strings back into Int/Float/
+      Bool/Date (v2.1 tighten, TODO.refactor/47).
+    additionalProperties: false
+    properties:
+      key:   { type: string }
+      type:  { type: string, enum: [string, integer, float, boolean, date, datetime] }
+
+      # String variant — wire name `value` (v2.0 back-compat).
+      value: { type: string }
+
+      # Typed variants (v2.1) — snake_case wire names (the gem uses
+      # snake_case Ruby attr names; lutaml-model emits them as-is).
+      integer_value:    { type: integer }
+      float_value:      { type: number }
+      boolean_value:    { type: boolean }
+      date_value:       { type: string, format: date }
+      date_time_value:  { type: string, format: date-time }
+
+  MeetingExtension:
+    type: object
+    description: |
+      Profile-specific extension. Adopters register their namespace via
+      `profile` and discriminate via `kind`. Field semantics tightened
+      v2.1 (TODO.refactor/47): `kind` is the in-profile discriminator,
+      `ref` is the URN of an external profile document, and the
+      recursive `extensions[]` slot was removed (YAGNI — use dotted
+      keys in `attributes[]` for nesting).
+    additionalProperties: false
+    properties:
+      profile: { type: string }
+      kind:    { type: string }
+      ref:     { type: string }
+      attributes:
+        type: array
+        items:
+          $ref: "#/$defs/ExtensionAttribute"
+
+  # ====================================================================
+  # Shared structural types.
+  # ====================================================================
+
+  Person:
+    type: object
+    description: "Identity + role + affiliation + contact."
+    additionalProperties: false
+    properties:
+      name:        { type: string }
+      kind:        { type: string }
+      role:        { type: string }
+      affiliation: { type: string }
+      email:       { type: string }
+      phone:       { type: string }
+      orcid:       { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Reference:
+    type: object
+    description: "Generic document reference."
+    additionalProperties: false
+    properties:
+      ref:   { type: string }
+      kind:  { type: string }
+      title: { type: string }
+
+  VoteRecord:
+    type: object
+    description: "One vote by one person on one decision/voting."
+    additionalProperties: false
+    required: [person, vote]
+    properties:
+      decision_ref: { type: string }
+      voting_ref:   { type: string }
+      person:       { $ref: "#/$defs/Person" }
+      affiliation:  { type: string }
+      vote:         { $ref: "#/$defs/VoteType" }
+      role:         { type: string }
+      notes:        { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Officer:
+    type: object
+    description: "A person holding a structural role in a Meeting."
+    additionalProperties: false
+    properties:
+      role:        { $ref: "#/$defs/OfficerRole" }
+      person:      { $ref: "#/$defs/Person" }
+      term_start:  { type: string, format: date }
+      term_end:    { type: string, format: date }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  ComponentLocalization:
+    type: object
+    description: "Per-language content for a MeetingComponent."
+    additionalProperties: false
+    required: [language_code]
+    properties:
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      script:
+        type: string
+        pattern: "^[A-Z][a-z]{3}$"
+      title:       { type: string }
+      description: { type: string }
+
+  MeetingComponent:
+    type: object
+    description: "Flat sub-event of a Meeting."
+    additionalProperties: false
+    properties:
+      identifier:  { type: string }
+      urn:         { type: string }
+      kind:        { $ref: "#/$defs/ComponentKind" }
+      body_type:   { type: string }
+      title:       { type: string }
+      description: { type: string }
+      starts_at:   { type: string, format: date-time }
+      ends_at:     { type: string, format: date-time }
+      venue_refs:
+        type: array
+        items: { type: string }
+      chair:       { $ref: "#/$defs/Person" }
+      agenda_ref:  { type: string }
+      minutes_ref: { type: string }
+      attendance_refs:
+        type: array
+        items: { type: string }
+      localizations:
+        type: array
+        items:
+          $ref: "#/$defs/ComponentLocalization"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  MeetingSeries:
+    type: object
+    description: "Parent of recurring Meeting instances."
+    additionalProperties: false
+    properties:
+      identifier:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      urn:           { type: string }
+      name:          { type: string }
+      description:   { type: string }
+      recurrence:    { $ref: "#/$defs/Recurrence" }
+      term:          { type: string }
+      organizer:     { $ref: "#/$defs/Person" }
+      hosts:
+        type: array
+        items:
+          $ref: "#/$defs/HostRef"
+      kind:          { type: string }
+      meeting_refs:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  HostRef:
+    type: object
+    description: "Typed reference to a hosting organization."
+    additionalProperties: false
+    required: [ref]
+    properties:
+      ref:     { type: string }
+      type:    { $ref: "#/$defs/HostType" }
+      role:    { type: string }
+      contact: { $ref: "#/$defs/Person" }
+
+  # ====================================================================
+  # Enums. Each value-list must equal the matching Edoxen::Enums::*
+  # frozen array; spec/edoxen/schema_enum_sync_spec.rb enforces.
+  # ====================================================================
+
+  ActionType:
+    type: string
+    description: |
+      Action verb. Edoxen::Enums::ACTION_TYPE lists the canonical set
+      (28 values). The schema is permissive — adopters may use
+      body-specific verbs (e.g. "scopes", "directs", "establishes")
+      outside the canonical set. The canonical set is advisory; the
+      body_vocabulary mechanism (v2.1, TODO.refactor/46) will
+      eventually map body-specific verbs to canonical types.
+
+  ConsiderationType:
+  ConsiderationType:
+    type: string
+    description: |
+      Consideration verb. Edoxen::Enums::CONSIDERATION_TYPE lists the
+      canonical set. The schema is permissive — adopters may use
+      body-specific verbs outside the canonical set (same rationale as
+      ActionType).
+
+  ApprovalType:
+    type: string
+    description: "Edoxen::Enums::APPROVAL_TYPE."
+    enum: [affirmative, negative]
+
+  ApprovalDegree:
+    type: string
+    description: "Edoxen::Enums::APPROVAL_DEGREE."
+    enum: [unanimous, majority, minority]
+
+  DecisionKind:
+    type: string
+    description: "Edoxen::Enums::DECISION_KIND."
+    enum: [resolution, order, ruling, determination, recommendation, statement, finding, opinion, other]
+
+  DecisionKindCanonical:
+    type: string
+    description: |
+      Edoxen::Enums::DECISION_KIND_CANONICAL — short abstract set (v2.1,
+      TODO.refactor/46). Bodies extend via `body_type` + per-dataset
+      `body_vocabulary[]`.
+    enum: [decision, recommendation, statement, finding, other]
+
+  DecisionStatus:
+    type: string
+    description: "Edoxen::Enums::DECISION_STATUS."
+    enum: [draft, proposed, under_consideration, decided, negatived, withdrawn, deferred]
+
+  DecisionDateType:
+    type: string
+    description: "Edoxen::Enums::DECISION_DATE_TYPE."
+    enum: [adoption, drafted, discussed, proposed, decided, negatived, withdrawn, published, effective]
+
+  DecisionRelationType:
+    type: string
+    description: "Edoxen::Enums::DECISION_RELATION_TYPE."
+    enum: [annexOf, hasAnnex, updates, refines, replaces, considers, cites]
+
+  MotionStatus:
+    type: string
+    description: "Edoxen::Enums::MOTION_STATUS."
+    enum: [introduced, seconded, debating, question_put, voting, carried, negatived, withdrawn, lapsed]
+
+  VotingStatus:
+    type: string
+    description: "Edoxen::Enums::VOTING_STATUS."
+    enum: [called, in_progress, decided, withdrawn, deferred]
+
+  VotingMethod:
+    type: string
+    description: "Edoxen::Enums::VOTING_METHOD."
+    enum: [voice, division, show_of_hands, roll_call, electronic, secret_ballot, unanimous_consent, consensus]
+
+  VotingOutcome:
+    type: string
+    description: "Edoxen::Enums::VOTING_OUTCOME."
+    enum: [passed, negatived, tied, withdrawn]
+
+  TopicStatus:
+    type: string
+    description: "Edoxen::Enums::TOPIC_STATUS."
+    enum: [open, under_discussion, decided, deferred, withdrawn]
+
+  VenueKind:
+    type: string
+    description: "Edoxen::Enums::VENUE_KIND."
+    enum: [physical, virtual]
+
+  VirtualFeature:
+    type: string
+    description: "Edoxen::Enums::VIRTUAL_FEATURE."
+    enum: [audio, video, chat, phone, screen, feed]
+
+  Visibility:
+    type: string
+    description: "Edoxen::Enums::VISIBILITY."
+    enum: [public, private, confidential]
+
+  AttendanceRole:
+    type: string
+    description: "Edoxen::Enums::ATTENDANCE_ROLE."
+    enum: [chair, required, optional, non_participant]
+
+  AttendanceResponse:
+    type: string
+    description: "Edoxen::Enums::ATTENDANCE_RESPONSE."
+    enum: [pending, confirmed, declined, tentative, delegated]
+
+  ComponentKind:
+    type: string
+    description: "Edoxen::Enums::COMPONENT_KIND."
+    enum: [track, session, debate, breakout, bof, plenary_session, working_group_session, committee_of_the_whole, keynote, address, statement, question_time, opening, closing, break, reception, registration, networking, other]
+
+  ComponentKindCanonical:
+    type: string
+    description: |
+      Edoxen::Enums::COMPONENT_KIND_CANONICAL — short abstract set
+      (v2.1, TODO.refactor/46).
+    enum: [deliberative, working, ceremonial, break, other]
+
+  OfficerRole:
+    type: string
+    description: "Edoxen::Enums::OFFICER_ROLE."
+    enum: [chair, vice_chair, deputy_chair, secretary, treasurer, parliamentarian, presiding_officer, sergeant_at_arms, other]
+
+  RecurrenceFreq:
+    type: string
+    description: "Edoxen::Enums::RECURRENCE_FREQ."
+    enum: [secondly, minutely, hourly, daily, weekly, monthly, yearly]
+
+  UrlKind:
+    type: string
+    description: "Edoxen::Enums::URL_KIND."
+    enum: [access, report]
+
+  SourceUrlKind:
+    type: string
+    description: "Edoxen::Enums::SOURCE_URL_KIND."
+    enum: [agenda_pdf, minutes_pdf, decisions_pdf, report_pdf, register_url, landing_page]
+
+  HostType:
+    type: string
+    description: "Edoxen::Enums::HOST_TYPE."
+    enum: [national_body, liaison, associate, organizer]
+
+  VoteType:
+    type: string
+    description: "Edoxen::Enums::VOTE_TYPE."
+    enum: [affirmative, negative, abstain, absent, not_applicable]

--- a/schema/examples/agenda-example.yaml
+++ b/schema/examples/agenda-example.yaml
@@ -1,0 +1,22 @@
+status: final
+source_doc: https://www.oiml.org/en/structure/ciml/pdf/56-ciml-agenda.pdf
+items:
+- label: '1'
+  kind: opening
+  title: Opening of the meeting
+  outcome: adopted
+- label: '2'
+  kind: numbered
+  title: Approval of the agenda
+  outcome: adopted
+  topics:
+  - identifier: agenda-approval
+    title: Approval of the 56th CIML Meeting agenda
+    status: decided
+- label: '3'
+  kind: numbered
+  title: Approval of the minutes of the 55th CIML Meeting
+  outcome: adopted
+- label: '9'
+  kind: aob
+  title: Any Other Business

--- a/schema/examples/decision-example.yaml
+++ b/schema/examples/decision-example.yaml
@@ -1,0 +1,58 @@
+---
+metadata:
+  title: 56th CIML meeting (2025) - Resolution 44 (multilingual)
+  date: 2025-10-13
+  source: BIML Secretariat
+  city: CNSHA
+  country_code: DE
+  title_localized:
+    - language_code: eng
+      script: Latn
+      title: 56th CIML meeting (2025) — Resolutions
+    - language_code: fra
+      script: Latn
+      title: 56e réunion du CIML (2025) — Résolutions
+  source_urls:
+    - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
+      format: pdf
+      language_code: eng
+    - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
+      format: pdf
+      language_code: fra
+decisions:
+  - identifier:
+    - prefix: CIML
+      number: "2025-44"
+    kind: resolution
+    status: decided
+    doi: 10.63493/resolutions/ciml202544
+    urn: urn:oiml:doc:ciml:resolution:2025-44
+    agenda_item: "16.2"
+    dates:
+      - date: 2025-10-13
+        type: discussed
+    localizations:
+      - language_code: eng
+        script: Latn
+        title: Decision on the renewal of the contract of Mr Anthony Donnellan
+        subject: CIML
+        actions:
+          - type: decides
+            date_effective:
+              date: 2025-10-13
+              type: adoption
+            message: |
+              The Committee decides to renew the contract of
+              Mr Anthony Donnellan as BIML Director.
+      - language_code: fra
+        script: Latn
+        title: Décision sur le renouvellement du contrat de M. Anthony Donnellan
+        subject: CIML
+        actions:
+          - type: decides
+            date_effective:
+              date: 2025-10-13
+              type: adoption
+            message: |
+              Le Comité décide de renouveler le contrat de
+              M. Anthony Donnellan en tant que Directeur du BIML.

--- a/schema/examples/meeting-example.yaml
+++ b/schema/examples/meeting-example.yaml
@@ -1,0 +1,174 @@
+---
+identifier:
+- prefix: CIML
+  number: '56'
+urn: urn:oiml:ciml:meeting:ciml-56
+ordinal: 56
+type: plenary
+status: completed
+visibility: public
+date_range:
+  start: 2025-10-13
+  end: 2025-10-17
+series_ref: urn:oiml:ciml:meeting-series
+venues:
+- kind: physical
+  name: Hôtel Mercure Paris Montmartre
+  unlocode: FRPAR
+  address: 3 Rue Caulaincourt, 75018 Paris, France
+  country_code: FR
+  lat: 48.8842
+  lon: 2.3395
+  room: Salle Turgot
+- kind: virtual
+  name: Video Conference (optional remote participation)
+  label: Zoom — Members only
+  uri: https://oiml.zoom.us/j/987654321
+  passcode: CIML56
+  features:
+  - audio
+  - video
+  - screen
+general_area: Paris, France
+city: Paris
+country_code: FR
+committee: CIML
+committee_group: OIML
+officers:
+- role: chair
+  person:
+    name: Roman Schwartz
+    kind: member
+- role: secretary
+  person:
+    name: Anthony Donnellan
+    kind: public_officer
+    affiliation: BIML
+    email: secretary@biml.org
+hosts:
+- type: organization
+  name: OIML
+  identifier: oiml
+source_urls:
+- ref: https://www.oiml.org/en/structure/ciml/pdf/56-ciml-resolutions-english.pdf
+  format: pdf
+  language_code: eng
+  kind: decisions_pdf
+- ref: https://www.oiml.org/fr/structure/ciml/pdf/56-ciml-resolutions-french.pdf
+  format: pdf
+  language_code: fra
+  kind: decisions_pdf
+agenda:
+  status: final
+  source_doc: https://www.oiml.org/en/structure/ciml/pdf/56-ciml-agenda.pdf
+  items:
+  - label: '1'
+    kind: opening
+    title: Opening of the meeting
+    outcome: adopted
+  - label: '2'
+    kind: numbered
+    title: Approval of the agenda
+    outcome: adopted
+    topics:
+    - identifier: agenda-approval
+      title: Approval of the 56th CIML Meeting agenda
+      status: decided
+  - label: '3'
+    kind: numbered
+    title: Approval of the minutes of the 55th CIML Meeting
+    outcome: adopted
+  - label: '9'
+    kind: aob
+    title: Any Other Business
+deadlines:
+- date: 2025-09-30
+  description: Registration via OIML meeting platform
+attendance:
+- person:
+    name: Dr. Mariya Petrova
+    kind: member
+    affiliation: Bulgarian Institute of Metrology
+  status: present
+  role: required
+  response: confirmed
+- person:
+    name: Mr. Hiroshi Tanaka
+    kind: member
+    affiliation: NMIJ Japan
+  status: present
+  role: required
+  response: confirmed
+- person:
+    name: Dr. Sarah Mitchell
+    kind: member
+    affiliation: NIST USA
+  status: apologies
+  role: required
+  response: declined
+decisions:
+- identifier:
+  - prefix: CIML
+    number: 2025-44
+  kind: resolution
+  status: decided
+  doi: 10.63493/decisions/ciml202544
+  urn: urn:oiml:ciml:decision:2025-44
+  agenda_item: '16.2'
+  dates:
+  - date: 2025-10-13
+    type: discussed
+  - date: 2025-10-15
+    type: decided
+  brought_by_motions:
+  - urn:oiml:ciml:motion:2025-44-bring
+  about_topics:
+  - urn:oiml:ciml:topic:donnellan-contract-renewal
+  localizations:
+  - language_code: eng
+    script: Latn
+    title: Decision on the renewal of the contract of Mr Anthony Donnellan
+    subject: CIML
+    actions:
+    - type: decides
+      message: |
+        The Committee decides to renew the contract of
+        Mr Anthony Donnellan as BIML Director.
+motions:
+- identifier: motion-2025-44-bring
+  urn: urn:oiml:ciml:motion:2025-44-bring
+  text: |
+    I move that the Committee decides to renew the contract of
+    Mr Anthony Donnellan as BIML Director.
+  mover:
+    name: Roman Schwartz
+    kind: member
+  seconders:
+  - name: Dr. Mariya Petrova
+    kind: member
+  status: carried
+  introduced_at: 2025-10-15 14:30:00.000000000 +02:00
+  proposed_decision: urn:oiml:ciml:decision:2025-44
+  resulting_decision: urn:oiml:ciml:decision:2025-44
+votings:
+- identifier: voting-2025-44
+  urn: urn:oiml:ciml:voting:2025-44
+  on_motion: urn:oiml:ciml:motion:2025-44-bring
+  status: decided
+  voting_method: unanimous_consent
+  called_by:
+    name: Roman Schwartz
+    kind: member
+  called_at: 2025-10-15 14:35:00.000000000 +02:00
+  result_declared_at: 2025-10-15 14:36:00.000000000 +02:00
+  result: passed
+  vote_records: []
+localizations:
+- language_code: eng
+  script: Latn
+  title: 56th CIML Meeting
+  general_area: Paris, France
+- language_code: fra
+  script: Latn
+  title: 56e réunion du CIML
+  general_area: Paris, France

--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -1,0 +1,826 @@
+---
+$schema: "http://json-schema.org/draft-07/schema#"
+$id: "https://github.com/edoxen/edoxen-model/schema/meeting.yaml"
+title: "Edoxen Meeting Schema"
+description: |
+  Schema for validating Edoxen Meeting/Agenda YAML files.
+
+  Mirrors the canonical LutaML information model in
+  https://github.com/edoxen/edoxen-model/tree/main/models (meeting*.lutaml,
+  agenda*.lutaml, etc.).
+
+  The root accepts either a single Meeting or a MeetingCollection.
+
+  Enum lists in this schema are kept in lockstep with
+  Edoxen::Enums::* (Meeting side) by
+  `spec/edoxen/schema_meeting_enum_sync_spec.rb`.
+type: object
+oneOf:
+  - $ref: "#/$defs/MeetingCollection"
+  - $ref: "#/$defs/Meeting"
+
+$defs:
+
+  # ====================================================================
+  # Reused from schema/edoxen.yaml (re-declared here so this file is
+  # self-contained).
+  # ====================================================================
+
+  StructuredIdentifier:
+    type: object
+    description: "An identifier (prefix + number). A Decision carries 1..* of these."
+    additionalProperties: false
+    required: [prefix, number]
+    properties:
+      prefix: { type: string }
+      number: { type: string }
+
+  EntityRef:
+    type: object
+    description: |
+      Typed cross-reference between entities (v2.1, TODO.refactor/44).
+      Exactly one of `urn`, `identifier`, or `local_ref` should be set;
+      the gem's `EntityRef#valid?` enforces this in Ruby.
+    additionalProperties: false
+    properties:
+      urn:         { type: string }
+      identifier:  { $ref: "#/$defs/StructuredIdentifier" }
+      local_ref:   { type: string }
+      kind:        { type: string }
+      role:        { type: string }
+      note:        { type: string }
+
+  SourceUrl:
+    type: object
+    description: "Per-language canonical source URL (e.g. one PDF per language)."
+    additionalProperties: false
+    required: [ref]
+    properties:
+      ref:          { type: string }
+      format:       { type: string }
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      kind:
+        $ref: "#/$defs/SourceUrlKind"
+
+  DateRange:
+    type: object
+    description: "Start + end date pair for multi-day meetings."
+    additionalProperties: false
+    properties:
+      start:
+        type: string
+        format: date
+      end:
+        type: string
+        format: date
+
+  Person:
+    type: object
+    description: "Identity + role + affiliation + contact."
+    additionalProperties: false
+    properties:
+      name:        { type: string }
+      kind:        { type: string }
+      role:        { type: string }
+      affiliation: { type: string }
+      email:       { type: string }
+      phone:       { type: string }
+      orcid:       { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  HostRef:
+    type: object
+    description: "Typed reference to a hosting organization."
+    additionalProperties: false
+    required: [ref]
+    properties:
+      ref:     { type: string }
+      type:    { $ref: "#/$defs/HostType" }
+      role:    { type: string }
+      contact: { $ref: "#/$defs/Person" }
+
+  Attendance:
+    type: object
+    description: "One attendance record per person at a Meeting."
+    additionalProperties: false
+    required: [person, status]
+    properties:
+      person:      { $ref: "#/$defs/Person" }
+      status:      { $ref: "#/$defs/ParticipationStatus" }
+      role:        { $ref: "#/$defs/AttendanceRole" }
+      response:    { $ref: "#/$defs/AttendanceResponse" }
+      affiliation: { type: string }
+      proxy_for:   { $ref: "#/$defs/Person" }
+      notes:       { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  VoteRecord:
+    type: object
+    description: "One vote by one person on one decision/voting."
+    additionalProperties: false
+    required: [person, vote]
+    properties:
+      decision_ref: { type: string }
+      voting_ref:   { type: string }
+      person:       { $ref: "#/$defs/Person" }
+      affiliation:  { type: string }
+      vote:         { $ref: "#/$defs/VoteType" }
+      role:         { type: string }
+      notes:        { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  MinutesSection:
+    type: object
+    description: "One section of a Meeting's minutes — typically tied to an agenda item by `number`."
+    additionalProperties: false
+    properties:
+      number:      { type: string }
+      title:       { type: string }
+      narrative:   { type: string }
+      page_start:  { type: integer }
+      page_end:    { type: integer }
+      references:
+        type: array
+        items:
+          $ref: "#/$defs/Reference"
+
+  Minutes:
+    type: object
+    description: |
+      The narrative record of a Meeting — what was said, by whom, in
+      what order, with what outcome. Distinct from Agenda and from
+      DecisionCollection.
+    additionalProperties: false
+    properties:
+      identifier:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      urn:           { type: string }
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      script:
+        type: string
+        pattern: "^[A-Z][a-z]{3}$"
+      source_doc:    { type: string }
+      source_pages:  { type: string }
+      sections:
+        type: array
+        items:
+          $ref: "#/$defs/MinutesSection"
+
+  Deadline:
+    type: object
+    description: "A time-bound requirement (registration, submission, etc.)."
+    additionalProperties: false
+    required: [date]
+    properties:
+      date:
+        type: string
+        format: date
+      description: { type: string }
+
+  Reference:
+    type: object
+    description: "Generic document reference."
+    additionalProperties: false
+    properties:
+      ref:   { type: string }
+      kind:  { type: string }
+      title: { type: string }
+
+  # ====================================================================
+  # Agenda side.
+  # ====================================================================
+
+  AgendaItem:
+    type: object
+    description: "One entry on an Agenda."
+    additionalProperties: false
+    properties:
+      label:       { type: string }
+      kind:        { $ref: "#/$defs/AgendaItemKind" }
+      title:       { type: string }
+      description: { type: string }
+      references:
+        type: array
+        items:
+          $ref: "#/$defs/Reference"
+      outcome:       { $ref: "#/$defs/AgendaItemOutcome" }
+      decision_ref:  { type: string }
+      topics:
+        type: array
+        items:
+          $ref: "#/$defs/Topic"
+      components:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Agenda:
+    type: object
+    description: |
+      The business-order document of a Meeting. Versioned independently
+      of the Meeting via the `status` field (draft, final, amended).
+    additionalProperties: false
+    properties:
+      identifier:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      status:      { $ref: "#/$defs/AgendaStatus" }
+      source_doc:  { type: string }
+      items:
+        type: array
+        items:
+          $ref: "#/$defs/AgendaItem"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Topic, Venue, Recurrence, MeetingExtension (shared with edoxen.yaml).
+  # ====================================================================
+
+  TopicDocument:
+    type: object
+    description: "Text-bearing document about a Topic."
+    additionalProperties: false
+    properties:
+      identifier:    { type: string }
+      title:         { type: string }
+      version:       { type: string }
+      status:        { type: string }
+      url:           { type: string }
+      format:        { type: string }
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  TopicAsset:
+    type: object
+    description: "Non-text resource about a Topic."
+    additionalProperties: false
+    properties:
+      identifier: { type: string }
+      title:      { type: string }
+      kind:       { type: string }
+      url:        { type: string }
+      format:     { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Topic:
+    type: object
+    description: "The subject of discussion at a Meeting."
+    additionalProperties: false
+    properties:
+      identifier:     { type: string }
+      urn:            { type: string }
+      title:          { type: string }
+      description:    { type: string }
+      status:         { $ref: "#/$defs/TopicStatus" }
+      resumption_of:  { type: string }
+      documents:
+        type: array
+        items:
+          $ref: "#/$defs/TopicDocument"
+      assets:
+        type: array
+        items:
+          $ref: "#/$defs/TopicAsset"
+      references:
+        type: array
+        items:
+          $ref: "#/$defs/Reference"
+      motions:
+        type: array
+        items: { type: string }
+      decisions:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Venue:
+    type: object
+    description: |
+      Polymorphic place where a Meeting happens. `kind` discriminates
+      physical vs virtual; all fields from both subtypes live here as
+      optional siblings. Validators (Edoxen::VenueValidator) enforce
+      that fields match `kind`.
+    additionalProperties: false
+    properties:
+      kind:              { $ref: "#/$defs/VenueKind" }
+      name:              { type: string }
+      label:             { type: string }
+      description:       { type: string }
+      capacity:          { type: integer }
+      url:               { type: string }
+
+      unlocode:
+        type: string
+        pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
+      iata_code:
+        type: string
+        pattern: "^[A-Z]{3}$"
+      address:           { type: string }
+      city:              { type: string }
+      country_code:
+        type: string
+        pattern: "^[A-Z]{2}$"
+      lat:               { type: number }
+      lon:               { type: number }
+      building:          { type: string }
+      floor:             { type: string }
+      room:              { type: string }
+      access_notes:      { type: string }
+
+      uri:               { type: string }
+      features:
+        type: array
+        items:
+          $ref: "#/$defs/VirtualFeature"
+      passcode:                 { type: string }
+      meeting_id:               { type: string }
+      dial_in_numbers:
+        type: array
+        items: { type: string }
+      waiting_room:             { type: boolean }
+      registration_required:    { type: boolean }
+
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  RecurrenceByDay:
+    type: object
+    description: "BYDAY part of a recurrence. `ordinal` is null for 'every', +1 for first, -1 for last."
+    additionalProperties: false
+    properties:
+      ordinal: { type: integer }
+      weekday: { type: string }
+
+  Recurrence:
+    type: object
+    description: "Structured ISO 8601-2 §13 recurrence."
+    additionalProperties: false
+    properties:
+      freq:        { $ref: "#/$defs/RecurrenceFreq" }
+      interval:    { type: integer }
+      count:       { type: integer }
+      until:       { type: string, format: date-time }
+      by_day:
+        type: array
+        items:
+          $ref: "#/$defs/RecurrenceByDay"
+      by_month_day:
+        type: array
+        items: { type: integer }
+      by_month:
+        type: array
+        items: { type: integer }
+      by_week_no:
+        type: array
+        items: { type: integer }
+      by_year_day:
+        type: array
+        items: { type: integer }
+      by_hour:
+        type: array
+        items: { type: integer }
+      by_minute:
+        type: array
+        items: { type: integer }
+      by_second:
+        type: array
+        items: { type: integer }
+      by_set_pos:
+        type: array
+        items: { type: integer }
+      week_start: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  ExtensionAttribute:
+    type: object
+    description: |
+      One typed key/value pair within a MeetingExtension. Polymorphic on
+      value type so consumers don't re-parse strings back into Int/Float/
+      Bool/Date (v2.1 tighten, TODO.refactor/47).
+    additionalProperties: false
+    properties:
+      key:   { type: string }
+      type:  { type: string, enum: [string, integer, float, boolean, date, datetime] }
+      value:           { type: string }
+      integer_value:    { type: integer }
+      float_value:      { type: number }
+      boolean_value:    { type: boolean }
+      date_value:       { type: string, format: date }
+      date_time_value:  { type: string, format: date-time }
+
+  MeetingExtension:
+    type: object
+    description: |
+      Profile-specific extension. Adopters register their namespace via
+      `profile` and discriminate via `kind`. Field semantics tightened
+      v2.1 (TODO.refactor/47): `kind` is the in-profile discriminator,
+      `ref` is the URN of an external profile document, and the
+      recursive `extensions[]` slot was removed (YAGNI — use dotted
+      keys in `attributes[]` for nesting).
+    additionalProperties: false
+    properties:
+      profile: { type: string }
+      kind:    { type: string }
+      ref:     { type: string }
+      attributes:
+        type: array
+        items:
+          $ref: "#/$defs/ExtensionAttribute"
+
+  Officer:
+    type: object
+    description: "A person holding a structural role in a Meeting."
+    additionalProperties: false
+    properties:
+      role:        { $ref: "#/$defs/OfficerRole" }
+      person:      { $ref: "#/$defs/Person" }
+      term_start:  { type: string, format: date }
+      term_end:    { type: string, format: date }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  ComponentLocalization:
+    type: object
+    description: "Per-language content for a MeetingComponent."
+    additionalProperties: false
+    required: [language_code]
+    properties:
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      script:
+        type: string
+        pattern: "^[A-Z][a-z]{3}$"
+      title:       { type: string }
+      description: { type: string }
+
+  MeetingComponent:
+    type: object
+    description: "Flat sub-event of a Meeting."
+    additionalProperties: false
+    properties:
+      identifier:  { type: string }
+      urn:         { type: string }
+      kind:        { $ref: "#/$defs/ComponentKind" }
+      body_type:   { type: string }
+      title:       { type: string }
+      description: { type: string }
+      starts_at:   { type: string, format: date-time }
+      ends_at:     { type: string, format: date-time }
+      venue_refs:
+        type: array
+        items: { type: string }
+      chair:       { $ref: "#/$defs/Person" }
+      agenda_ref:  { type: string }
+      minutes_ref: { type: string }
+      attendance_refs:
+        type: array
+        items: { type: string }
+      localizations:
+        type: array
+        items:
+          $ref: "#/$defs/ComponentLocalization"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  MeetingSeries:
+    type: object
+    description: "Parent of recurring Meeting instances."
+    additionalProperties: false
+    properties:
+      identifier:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      urn:           { type: string }
+      name:          { type: string }
+      description:   { type: string }
+      recurrence:    { $ref: "#/$defs/Recurrence" }
+      term:          { type: string }
+      organizer:     { $ref: "#/$defs/Person" }
+      hosts:
+        type: array
+        items:
+          $ref: "#/$defs/HostRef"
+      kind:          { type: string }
+      meeting_refs:
+        type: array
+        items: { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  # ====================================================================
+  # Meeting side.
+  # ====================================================================
+
+  MeetingRelation:
+    type: object
+    description: "Directed link between two meetings."
+    additionalProperties: false
+    required: [source, destination, type]
+    properties:
+      source:     { $ref: "#/$defs/StructuredIdentifier" }
+      destination: { $ref: "#/$defs/StructuredIdentifier" }
+      type:       { $ref: "#/$defs/MeetingRelationType" }
+
+  MeetingLocalization:
+    type: object
+    description: "Per-language content for a Meeting."
+    additionalProperties: false
+    required: [language_code]
+    properties:
+      language_code:
+        type: string
+        pattern: "^[a-z]{3}$"
+      script:
+        type: string
+        pattern: "^[A-Z][a-z]{3}$"
+      title:          { type: string }
+      general_area:   { type: string }
+      practical_info: { type: string }
+
+  Meeting:
+    type: object
+    description: "A single Meeting (event)."
+    additionalProperties: false
+    required: [identifier, type]
+    properties:
+      identifier:
+        type: array
+        minItems: 1
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      urn:                { type: string }
+      ordinal:            { type: integer }
+      series_ref:         { type: string }
+      type:               { $ref: "#/$defs/MeetingType" }
+      status:             { $ref: "#/$defs/MeetingStatus" }
+      visibility:         { $ref: "#/$defs/Visibility" }
+      body_type:          { type: string }
+
+      date_range:         { $ref: "#/$defs/DateRange" }
+      recurrence:         { $ref: "#/$defs/Recurrence" }
+
+      venues:
+        type: array
+        items:
+          $ref: "#/$defs/Venue"
+      general_area:       { type: string }
+      city:
+        type: string
+        pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
+      country_code:
+        type: string
+        pattern: "^[A-Z]{2}$"
+
+      committee:          { type: string }
+      committee_group:    { type: string }
+
+      officers:
+        type: array
+        items:
+          $ref: "#/$defs/Officer"
+      hosts:
+        type: array
+        items:
+          $ref: "#/$defs/HostRef"
+
+      source_urls:
+        type: array
+        items:
+          $ref: "#/$defs/SourceUrl"
+      landing_url:        { type: string }
+      registration_url:   { type: string }
+
+      agenda:             { $ref: "#/$defs/Agenda" }
+      components:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingComponent"
+      deadlines:
+        type: array
+        items:
+          $ref: "#/$defs/Deadline"
+      attendance:
+        type: array
+        items:
+          $ref: "#/$defs/Attendance"
+      minutes:
+        type: array
+        items:
+          $ref: "#/$defs/Minutes"
+
+      decisions:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      motions:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+      votings:
+        type: array
+        items:
+          $ref: "#/$defs/StructuredIdentifier"
+
+      localizations:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingLocalization"
+      relations:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingRelation"
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  MeetingCollectionMetadata:
+    type: object
+    description: "Display-level metadata for a MeetingCollection."
+    additionalProperties: false
+    properties:
+      title:  { type: string }
+      source: { type: string }
+      body_vocabulary:
+        type: array
+        items:
+          $ref: "#/$defs/BodyVocabularyEntry"
+
+  BodyVocabularyEntry:
+    type: object
+    description: |
+      One entry in a per-dataset body_vocabulary list (v2.1,
+      TODO.refactor/46). Maps a free-form body_type to a short
+      canonical value. SSOT for body_type -> canonical_type resolution
+      within the declaring collection.
+    additionalProperties: false
+    properties:
+      body_type:      { type: string }
+      canonical_type: { type: string }
+      definition:     { type: string }
+
+  MeetingCollection:
+    type: object
+    description: "Top-level wrapper for many Meetings in one file."
+    additionalProperties: false
+    required: [meetings]
+    properties:
+      metadata:
+        $ref: "#/$defs/MeetingCollectionMetadata"
+      meetings:
+        type: array
+        items:
+          $ref: "#/$defs/Meeting"
+
+  # ====================================================================
+  # Enums.
+  # ====================================================================
+
+  MeetingType:
+    type: string
+    description: "Edoxen::Enums::MEETING_TYPE."
+    enum: [plenary, working_group, task_group, ad_hoc, joint, general_assembly, committee, subcommittee, conference, workshop, seminar, webinar, hearing, markup, board_meeting, annual_general_meeting, other]
+
+  MeetingTypeCanonical:
+    type: string
+    description: |
+      Edoxen::Enums::MEETING_TYPE_CANONICAL — short abstract set (v2.1,
+      TODO.refactor/46). No `other` escape — bodies pick the closest
+      fit and use `body_type` for body-specific terminology.
+    enum: [plenary, governing, working, advisory]
+
+  MeetingStatus:
+    type: string
+    description: "Edoxen::Enums::MEETING_STATUS."
+    enum: [upcoming, completed, cancelled]
+
+  AgendaStatus:
+    type: string
+    description: "Edoxen::Enums::AGENDA_STATUS."
+    enum: [draft, final, amended, cancelled, superseded]
+
+  AgendaItemKind:
+    type: string
+    description: "Edoxen::Enums::AGENDA_ITEM_KIND."
+    enum: [numbered, unnumbered, header, opening, closing, aob]
+
+  AgendaItemOutcome:
+    type: string
+    description: "Edoxen::Enums::AGENDA_ITEM_OUTCOME."
+    enum: [discussed, resolved, deferred, adopted, withdrawn, carried, negatived]
+
+  HostType:
+    type: string
+    description: "Edoxen::Enums::HOST_TYPE."
+    enum: [national_body, liaison, associate, organizer]
+
+  MeetingRelationType:
+    type: string
+    description: "Edoxen::Enums::MEETING_RELATION_TYPE."
+    enum: [continues_from, continues_to, joint_with, supersedes, superseded_by, rescheduled_from, rescheduled_to, parent_of, child_of, sibling_of, depends_on, finish_to_start, finish_to_finish, start_to_start, start_to_finish]
+
+  SourceUrlKind:
+    type: string
+    description: "Edoxen::Enums::SOURCE_URL_KIND."
+    enum: [agenda_pdf, minutes_pdf, decisions_pdf, report_pdf, register_url, landing_page]
+
+  ParticipationStatus:
+    type: string
+    description: "Edoxen::Enums::PARTICIPATION_STATUS."
+    enum: [present, absent, apologies, observer, excused]
+
+  AttendanceRole:
+    type: string
+    description: "Edoxen::Enums::ATTENDANCE_ROLE."
+    enum: [chair, required, optional, non_participant]
+
+  AttendanceResponse:
+    type: string
+    description: "Edoxen::Enums::ATTENDANCE_RESPONSE."
+    enum: [pending, confirmed, declined, tentative, delegated]
+
+  VoteType:
+    type: string
+    description: "Edoxen::Enums::VOTE_TYPE."
+    enum: [affirmative, negative, abstain, absent, not_applicable]
+
+  TopicStatus:
+    type: string
+    description: "Edoxen::Enums::TOPIC_STATUS."
+    enum: [open, under_discussion, decided, deferred, withdrawn]
+
+  VenueKind:
+    type: string
+    description: "Edoxen::Enums::VENUE_KIND."
+    enum: [physical, virtual]
+
+  VirtualFeature:
+    type: string
+    description: "Edoxen::Enums::VIRTUAL_FEATURE."
+    enum: [audio, video, chat, phone, screen, feed]
+
+  Visibility:
+    type: string
+    description: "Edoxen::Enums::VISIBILITY."
+    enum: [public, private, confidential]
+
+  ComponentKind:
+    type: string
+    description: "Edoxen::Enums::COMPONENT_KIND."
+    enum: [track, session, debate, breakout, bof, plenary_session, working_group_session, committee_of_the_whole, keynote, address, statement, question_time, opening, closing, break, reception, registration, networking, other]
+
+  OfficerRole:
+    type: string
+    description: "Edoxen::Enums::OFFICER_ROLE."
+    enum: [chair, vice_chair, deputy_chair, secretary, treasurer, parliamentarian, presiding_officer, sergeant_at_arms, other]
+
+  RecurrenceFreq:
+    type: string
+    description: "Edoxen::Enums::RECURRENCE_FREQ."
+    enum: [secondly, minutely, hourly, daily, weekly, monthly, yearly]


### PR DESCRIPTION
The model repo is the canonical source of truth for the Edoxen information model. Until now, the JSON Schema files lived only in the gem (edoxen/edoxen/schema/). This PR brings them home.

## Added

- `schema/decision-collection.yaml` — validates DecisionCollection YAML
- `schema/meeting.yaml` — validates Meeting/MeetingCollection YAML
- `schema/examples/` — three worked examples (Decision, Meeting, Agenda)
- `schema/README.md` — describes the files and the lockstep invariant

The gem's copies stay as derived outputs.