### PR TITLE
feat(model): v2.2 OCP refactor — VCARD contacts, polymorphic methods/ids

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -5,6 +5,68 @@ All notable changes to this project will be documented in this file.
 The format is based on https://keepachangelog.com/en/1.1.0/[Keep a Changelog],
 and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
 
+== [2.2.0] — Unreleased
+
+Model refinements that close the v2.0 → v2.1 genericity gaps surfaced
+by migrating TC154's 25 custom event files. The core stays generic;
+adopter-specific structured data goes through `MeetingExtension`.
+
+=== Breaking changes (contact identity — VCARD-style)
+
+* New `Contact` class — VCARD-like abstract contact. Generalises
+  Person for cases where the contact may be a person, an organisation,
+  a department, or a role ("Secretariat").
+* New `Name` class — structured personal/organisational name (VCARD
+  N + FN). `Contact.name: Name` replaces `Person.name: String`.
+  Callers that always want a display string use `Name#display`
+  (returns `formatted` if set, else builds from components).
+* Removed `Person.email`, `Person.phone`, `Person.orcid`. Replaced by
+  the new `contactMethods: ContactMethod[0..*]` and `identifiers:
+  ContactIdentifier[0..*]` collections on Contact (Person inherits).
+  New channels and identifier schemes are added via enum values (or
+  `other` + extensions) — the model never changes (OCP).
+* `Person` now inherits from `Contact` (was a peer class). `Person` is
+  an empty subclass; all behaviour is inherited.
+* New `ContactMethod` — one polymorphic communication channel
+  (kind + value + label + primary). `ContactMethodKind`: phone,
+  mobile, fax, email, url, mail, pager, message, other.
+* New `ContactIdentifier` — one polymorphic external identifier
+  (kind + value). `ContactIdentifierKind`: orcid, isni, wikidata, ror,
+  ringgold, github, other.
+* `Venue.phones: String[0..*]` → `Venue.contactMethods: ContactMethod[0..*]`.
+  One polymorphic collection covers phone, fax, email, url, mail, etc.
+* `Meeting.localContact` → `Meeting.contact` — "local" had no
+  symmetric opposite and was indefensible. Type is now `Contact`.
+* `MeetingSeries.organizer` → `MeetingSeries.contact` — the
+  "organizer" semantic lives on `Contact#role`, not as a separate
+  field. Type is now `Contact`.
+* `HostRef.contact` type changed from `Person` to `Contact`.
+
+=== Breaking changes (component / venue location)
+
+* `MeetingComponent.chair: Person` → `MeetingComponent.officers: Officer[0..*]`.
+  One role-discriminated collection (mirrors `Meeting.officers`) instead
+  of a single chair slot — supports co-chairs, moderators, multiple
+  leaders. A derived `MeetingComponent#chair` accessor preserves
+  the convenience query.
+* Removed `MeetingComponent.rooms: String[0..*]`. A "room" is just a
+  `Venue` with `kind=physical`; reference it through the existing
+  `venueRefs` (which already supports both physical and virtual
+  sub-locations). No new field needed — Venue is already OCP for any
+  location kind.
+* `Venue.phone: String` → folded into `Venue.contactMethods`.
+
+=== Added
+
+* `Contact`, `Name`, `ContactMethod`, `ContactIdentifier` — VCARD-like
+  contact abstraction. OCP for new channels, identifier schemes, and
+  name components.
+* `Meeting.note: String` — general-purpose annotation on the meeting.
+* `Meeting.contact: Contact` — general contact (replaces the
+  indefensible `localContact`).
+* `MeetingComponent.timeLabel: String` — free-form time display
+  (e.g. `"9:00–10:30"`) for schedules without exact ISO timestamps.
+
 == [2.0.0] — 2026-07-04
 
 Edoxen-model v2.0 broadens the canonical information model from a

--- a/models/contact.lutaml
+++ b/models/contact.lutaml
@@ -1,0 +1,20 @@
+// Contact — VCARD-like abstract contact. Generalises Person for cases
+// where the contact may be a person, an organisation, a department, a
+// role ("Secretariat"), or any other entity that has a name and one or
+// more communication channels.
+//
+// Use Contact where the kind of contact is open or mixed (meeting
+// local-contact, meeting-series organiser, host-ref contact). Use
+// Person (which inherits from Contact) where the contact is
+// specifically an individual with identity (officer, attendee, voter).
+class Contact {
+  name: Name
+  kind: String
+  role: String
+  title: String
+  affiliation: String
+  contactMethods: ContactMethod[0..*]
+  identifiers: ContactIdentifier[0..*]
+  address: String
+  extensions: MeetingExtension[0..*]
+}

--- a/models/contact_identifier.lutaml
+++ b/models/contact_identifier.lutaml
@@ -1,0 +1,9 @@
+// ContactIdentifier — one polymorphic external identifier for a Contact.
+// Replaces the hard-coded `orcid` field. New identifier schemes (ISNI,
+// Wikidata QID, ROR, Ringgold, GitHub handle, etc.) are added via the
+// ContactIdentifierKind enum (or `other` + extensions) — no model change.
+class ContactIdentifier {
+  kind: ContactIdentifierKind
+  value: String
+  extensions: MeetingExtension[0..*]
+}

--- a/models/contact_identifier_kind.lutaml
+++ b/models/contact_identifier_kind.lutaml
@@ -1,0 +1,9 @@
+enum ContactIdentifierKind {
+  orcid
+  isni
+  wikidata
+  ror
+  ringgold
+  github
+  other
+}

--- a/models/contact_method.lutaml
+++ b/models/contact_method.lutaml
@@ -1,0 +1,16 @@
+// ContactMethod — one polymorphic communication channel. Replaces the
+// OCP-violating `email`/`phone`/`fax` etc. fields that hard-coded a
+// fixed set of channels on Person and Venue.
+//
+// `kind` discriminates the channel; `value` carries the address/number;
+// `label` is a free-form display hint ("Office", "Front desk",
+// "After hours"). New channel kinds are added via the ContactMethodKind
+// enum (or `other` + extensions for adopter-specific channels) — no
+// model change required.
+class ContactMethod {
+  kind: ContactMethodKind
+  value: String
+  label: String
+  primary: Boolean
+  extensions: MeetingExtension[0..*]
+}

--- a/models/contact_method_kind.lutaml
+++ b/models/contact_method_kind.lutaml
@@ -1,0 +1,11 @@
+enum ContactMethodKind {
+  phone
+  mobile
+  fax
+  email
+  url
+  mail
+  pager
+  message
+  other
+}

--- a/models/host_ref.lutaml
+++ b/models/host_ref.lutaml
@@ -2,5 +2,5 @@ class HostRef {
   ref: String
   type: HostType
   role: String
-  contact: Person
+  contact: Contact
 }

--- a/models/meeting.lutaml
+++ b/models/meeting.lutaml
@@ -20,6 +20,12 @@ class Meeting {
   sourceUrls: SourceUrl[0..*]
   landingUrl: String
   registrationUrl: String
+  // General-purpose annotation on the meeting (free-form note).
+  note: String
+  // General contact for this meeting (Contact#role discriminates:
+  // "organizer", "secretariat", "local organizer", etc.). Replaces the
+  // v2.2a `localContact` field — "local" had no symmetric opposite.
+  contact: Contact
   agenda: Agenda
   components: MeetingComponent[0..*]
   deadlines: Deadline[0..*]

--- a/models/meeting_component.lutaml
+++ b/models/meeting_component.lutaml
@@ -7,8 +7,16 @@ class MeetingComponent {
   description: String
   startsAt: DateTime
   endsAt: DateTime
+  // Free-form time display (e.g. "9:00–10:30") for schedules where
+  // exact ISO timestamps aren't available or timezone is unknown.
+  timeLabel: String
+  // References to specific Venue instances (rooms, halls, virtual
+  // breakouts) defined on the parent Meeting. A "room" is just a
+  // Venue with kind=physical — no separate location abstraction.
   venueRefs: String[0..*]
-  chair: Person
+  // Role-discriminated people leading or contributing to this component
+  // (chair, co-chair, moderator, speaker, etc.). Mirrors Meeting.officers.
+  officers: Officer[0..*]
   agendaRef: String
   minutesRef: String
   attendanceRefs: String[0..*]

--- a/models/meeting_localization.lutaml
+++ b/models/meeting_localization.lutaml
@@ -2,6 +2,11 @@
 // pattern used by `Localization` for Decisions: language-agnostic
 // admin fields live on the parent Meeting; per-language content
 // lives here.
+//
+// Structured practical info (accommodation options, transport details,
+// documents notes) goes via MeetingExtension on the parent Meeting —
+// the profile mechanism handles any body-specific structured data
+// without core model changes.
 class MeetingLocalization {
   languageCode: String
   script: String

--- a/models/meeting_series.lutaml
+++ b/models/meeting_series.lutaml
@@ -5,7 +5,7 @@ class MeetingSeries {
   description: String
   recurrence: Recurrence
   term: String
-  organizer: Person
+  contact: Contact
   hosts: HostRef[0..*]
   kind: String
   meetingRefs: String[0..*]

--- a/models/name.lutaml
+++ b/models/name.lutaml
@@ -1,0 +1,17 @@
+// Name — structured personal/organisational name. VCARD conventions
+// (RFC 6350): separate structured components (N) from a pre-formatted
+// display string (FN). Either or both may be populated.
+//
+// `formatted` is the display string when callers have it pre-built;
+// the structured fields (`family`, `given`, `additional`, `prefix`,
+// `suffix`) let adopters store parsed components for sorting, indexing,
+// or locale-aware rendering.
+class Name {
+  formatted: String
+  family: String
+  given: String
+  additional: String
+  prefix: String
+  suffix: String
+  extensions: MeetingExtension[0..*]
+}

--- a/models/person.lutaml
+++ b/models/person.lutaml
@@ -1,10 +1,7 @@
-class Person {
-  name: String
-  kind: String
-  role: String
-  affiliation: String
-  email: String
-  phone: String
-  orcid: String
-  extensions: MeetingExtension[0..*]
+// Person — a Contact that is specifically an individual human.
+// Inherits name/kind/role/title/affiliation/contactMethods/identifiers/
+// address/extensions from Contact. The old `email`, `phone`, and
+// `orcid` fields are replaced by entries in `contactMethods` (kind=email
+// or phone) and `identifiers` (kind=orcid).
+class Person < Contact {
 }

--- a/models/venue.lutaml
+++ b/models/venue.lutaml
@@ -14,6 +14,9 @@ class Venue {
   description: String
   capacity: Integer
   url: String
+  // Polymorphic contact channels for this venue (front-desk phone,
+  // reservations email, fax, etc.). Replaces the old `phones` field.
+  contactMethods: ContactMethod[0..*]
   // Physical-venue fields (populated when kind == "physical").
   unlocode: String
   iataCode: String


### PR DESCRIPTION
## Summary

Closes the genericity gaps surfaced by the TC154 event migration. The core stays generic; site-specific structured data goes through `MeetingExtension`.

**New VCARD-style abstractions (OCP-compliant):**
- `Contact` — abstract contact (person, organisation, department, or role).
- `Name` — structured N + FN components (formatted, family, given, additional, prefix, suffix).
- `ContactMethod` — polymorphic channel (phone/mobile/fax/email/url/mail/pager/message/other) — replaces hard-coded email/phone.
- `ContactIdentifier` — polymorphic external ID (orcid/isni/wikidata/ror/ringgold/github/other) — replaces hard-coded orcid.

**Field renames (asymmetric/role-specific → general):**
- `Meeting.localContact` → `Meeting.contact` (no symmetric 'globalContact' exists).
- `MeetingSeries.organizer` → `MeetingSeries.contact` (organizer is a role).
- `Venue.phones` → `Venue.contactMethods`.
- `MeetingComponent.chair: Person` → `officers: Officer[0..*]` (role-discriminated).
- Removed `MeetingComponent.rooms` (a room is a Venue with kind=physical — use venueRefs).
- Removed `MeetingLocalization.documentsNote/transport/accommodationOptions` + `AccommodationOption` (site-specific → MeetingExtension).

**Added:** `Meeting.note`, `MeetingComponent.timeLabel`.

Gem-side counterpart: edoxen/edoxen#28

## Test plan
- [ ] CI green
- [ ] Downstream gem sync spec picks up the new lutaml classes
- [ ] Downstream data migration (TC154/TC184) to Contact/Name shape in a follow-up