### PR TITLE
feat(schema): sync to v2.2 — EntityRef, Contact family, body_vocabulary

### DIFF
--- a/schema/decision-collection.yaml
+++ b/schema/decision-collection.yaml
@@ -474,6 +474,10 @@ $defs:
       description:       { type: string }
       capacity:          { type: integer }
       url:               { type: string }
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
 
       # Physical-venue fields.
       unlocode:
@@ -627,18 +631,122 @@ $defs:
   # Shared structural types.
   # ====================================================================
 
-  Person:
+  ContactMethodKind:
+    type: string
+    description: "Polymorphic communication channel kind."
+    enum: [phone, mobile, fax, email, url, mail, pager, message, other]
+
+  ContactMethod:
     type: object
-    description: "Identity + role + affiliation + contact."
+    description: |
+      One polymorphic communication channel — phone, email, fax, url,
+      mail, etc. `kind` discriminates the channel; `value` carries the
+      address/number; `label` is a free-form display hint ("Office",
+      "Front desk"). OCP: new channel kinds are added via the
+      ContactMethodKind enum (or `other` + extensions).
     additionalProperties: false
     properties:
-      name:        { type: string }
-      kind:        { type: string }
-      role:        { type: string }
-      affiliation: { type: string }
-      email:       { type: string }
-      phone:       { type: string }
-      orcid:       { type: string }
+      kind:        { $ref: "#/$defs/ContactMethodKind" }
+      value:       { type: string }
+      label:       { type: string }
+      primary:     { type: boolean }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  ContactIdentifierKind:
+    type: string
+    description: "Polymorphic external identifier scheme for a Contact."
+    enum: [orcid, isni, wikidata, ror, ringgold, github, other]
+
+  ContactIdentifier:
+    type: object
+    description: |
+      One polymorphic external identifier — ORCID, ISNI, Wikidata QID,
+      ROR, Ringgold, GitHub handle, etc. Replaces the hard-coded `orcid`
+      field. OCP: new identifier schemes are added via the
+      ContactIdentifierKind enum (or `other` + extensions).
+    additionalProperties: false
+    properties:
+      kind:        { $ref: "#/$defs/ContactIdentifierKind" }
+      value:       { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Name:
+    type: object
+    description: |
+      Structured personal/organisational name (VCARD RFC 6350
+      conventions). `formatted` is the pre-built display string (FN);
+      the structured components (N) are stored separately for sorting,
+      indexing, or locale-aware rendering.
+    additionalProperties: false
+    properties:
+      formatted:  { type: string }
+      family:     { type: string }
+      given:      { type: string }
+      additional: { type: string }
+      prefix:     { type: string }
+      suffix:     { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Contact:
+    type: object
+    description: |
+      VCARD-like abstract contact. Generalises Person for cases where
+      the contact may be a person, an organisation, a department, a
+      role ("Secretariat"), or any other entity with a name and one or
+      more communication channels.
+    additionalProperties: false
+    properties:
+      name:            { $ref: "#/$defs/Name" }
+      kind:            { type: string }
+      role:            { type: string }
+      title:           { type: string }
+      affiliation:     { type: string }
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
+      identifiers:
+        type: array
+        items:
+          $ref: "#/$defs/ContactIdentifier"
+      address:         { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Person:
+    type: object
+    description: |
+      A Contact that is specifically an individual human. Inherits all
+      Contact fields. The old `email`, `phone`, and `orcid` fields are
+      replaced by entries in `contact_methods` (kind=email / kind=phone)
+      and `identifiers` (kind=orcid).
+    additionalProperties: false
+    properties:
+      name:            { $ref: "#/$defs/Name" }
+      kind:            { type: string }
+      role:            { type: string }
+      title:           { type: string }
+      affiliation:     { type: string }
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
+      identifiers:
+        type: array
+        items:
+          $ref: "#/$defs/ContactIdentifier"
+      address:         { type: string }
       extensions:
         type: array
         items:
@@ -713,10 +821,14 @@ $defs:
       description: { type: string }
       starts_at:   { type: string, format: date-time }
       ends_at:     { type: string, format: date-time }
+      time_label:  { type: string }
       venue_refs:
         type: array
         items: { type: string }
-      chair:       { $ref: "#/$defs/Person" }
+      officers:
+        type: array
+        items:
+          $ref: "#/$defs/Officer"
       agenda_ref:  { type: string }
       minutes_ref: { type: string }
       attendance_refs:
@@ -745,7 +857,7 @@ $defs:
       description:   { type: string }
       recurrence:    { $ref: "#/$defs/Recurrence" }
       term:          { type: string }
-      organizer:     { $ref: "#/$defs/Person" }
+      contact:       { $ref: "#/$defs/Contact" }
       hosts:
         type: array
         items:
@@ -768,7 +880,7 @@ $defs:
       ref:     { type: string }
       type:    { $ref: "#/$defs/HostType" }
       role:    { type: string }
-      contact: { $ref: "#/$defs/Person" }
+      contact: { $ref: "#/$defs/Contact" }
 
   # ====================================================================
   # Enums. Each value-list must equal the matching Edoxen::Enums::*

--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -76,18 +76,119 @@ $defs:
         type: string
         format: date
 
-  Person:
+  ContactMethodKind:
+    type: string
+    description: "Polymorphic communication channel kind."
+    enum: [phone, mobile, fax, email, url, mail, pager, message, other]
+
+  ContactMethod:
     type: object
-    description: "Identity + role + affiliation + contact."
+    description: |
+      One polymorphic communication channel — phone, email, fax, url,
+      mail, etc. OCP: new channel kinds are added via the
+      ContactMethodKind enum (or `other` + extensions).
     additionalProperties: false
     properties:
-      name:        { type: string }
-      kind:        { type: string }
-      role:        { type: string }
-      affiliation: { type: string }
-      email:       { type: string }
-      phone:       { type: string }
-      orcid:       { type: string }
+      kind:        { $ref: "#/$defs/ContactMethodKind" }
+      value:       { type: string }
+      label:       { type: string }
+      primary:     { type: boolean }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  ContactIdentifierKind:
+    type: string
+    description: "Polymorphic external identifier scheme for a Contact."
+    enum: [orcid, isni, wikidata, ror, ringgold, github, other]
+
+  ContactIdentifier:
+    type: object
+    description: |
+      One polymorphic external identifier — ORCID, ISNI, Wikidata QID,
+      ROR, Ringgold, GitHub handle, etc. Replaces the hard-coded `orcid`
+      field. OCP: new identifier schemes are added via the
+      ContactIdentifierKind enum (or `other` + extensions).
+    additionalProperties: false
+    properties:
+      kind:        { $ref: "#/$defs/ContactIdentifierKind" }
+      value:       { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Name:
+    type: object
+    description: |
+      Structured personal/organisational name (VCARD RFC 6350
+      conventions). `formatted` is the pre-built display string (FN);
+      the structured components (N) are stored separately.
+    additionalProperties: false
+    properties:
+      formatted:  { type: string }
+      family:     { type: string }
+      given:      { type: string }
+      additional: { type: string }
+      prefix:     { type: string }
+      suffix:     { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Contact:
+    type: object
+    description: |
+      VCARD-like abstract contact. Generalises Person for cases where
+      the contact may be a person, an organisation, a department, a
+      role ("Secretariat"), or any other entity with a name and one or
+      more communication channels.
+    additionalProperties: false
+    properties:
+      name:            { $ref: "#/$defs/Name" }
+      kind:            { type: string }
+      role:            { type: string }
+      title:           { type: string }
+      affiliation:     { type: string }
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
+      identifiers:
+        type: array
+        items:
+          $ref: "#/$defs/ContactIdentifier"
+      address:         { type: string }
+      extensions:
+        type: array
+        items:
+          $ref: "#/$defs/MeetingExtension"
+
+  Person:
+    type: object
+    description: |
+      A Contact that is specifically an individual human. Inherits all
+      Contact fields. The old `email`, `phone`, and `orcid` fields are
+      replaced by entries in `contact_methods` (kind=email / kind=phone)
+      and `identifiers` (kind=orcid).
+    additionalProperties: false
+    properties:
+      name:            { $ref: "#/$defs/Name" }
+      kind:            { type: string }
+      role:            { type: string }
+      title:           { type: string }
+      affiliation:     { type: string }
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
+      identifiers:
+        type: array
+        items:
+          $ref: "#/$defs/ContactIdentifier"
+      address:         { type: string }
       extensions:
         type: array
         items:
@@ -102,7 +203,7 @@ $defs:
       ref:     { type: string }
       type:    { $ref: "#/$defs/HostType" }
       role:    { type: string }
-      contact: { $ref: "#/$defs/Person" }
+      contact: { $ref: "#/$defs/Contact" }
 
   Attendance:
     type: object
@@ -341,7 +442,10 @@ $defs:
       description:       { type: string }
       capacity:          { type: integer }
       url:               { type: string }
-
+      contact_methods:
+        type: array
+        items:
+          $ref: "#/$defs/ContactMethod"
       unlocode:
         type: string
         pattern: "^[A-Z]{2}[A-Z0-9]{3}$"
@@ -507,10 +611,14 @@ $defs:
       description: { type: string }
       starts_at:   { type: string, format: date-time }
       ends_at:     { type: string, format: date-time }
+      time_label:  { type: string }
       venue_refs:
         type: array
         items: { type: string }
-      chair:       { $ref: "#/$defs/Person" }
+      officers:
+        type: array
+        items:
+          $ref: "#/$defs/Officer"
       agenda_ref:  { type: string }
       minutes_ref: { type: string }
       attendance_refs:
@@ -539,7 +647,7 @@ $defs:
       description:   { type: string }
       recurrence:    { $ref: "#/$defs/Recurrence" }
       term:          { type: string }
-      organizer:     { $ref: "#/$defs/Person" }
+      contact:       { $ref: "#/$defs/Contact" }
       hosts:
         type: array
         items:
@@ -635,6 +743,8 @@ $defs:
           $ref: "#/$defs/SourceUrl"
       landing_url:        { type: string }
       registration_url:   { type: string }
+      note:               { type: string }
+      contact:            { $ref: "#/$defs/Contact" }
 
       agenda:             { $ref: "#/$defs/Agenda" }
       components:


### PR DESCRIPTION
Updates the canonical JSON Schema files to match the gem v2.2 release. The schemas grew from 1751 to 1973 lines reflecting EntityRef, Contact family, body_vocabulary, updated Meeting/Person/HostRef/Motion.