### PR TITLE
fix(schema): close 3 description drifts in meeting.yaml

### DIFF
--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -85,7 +85,9 @@ $defs:
     type: object
     description: |
       One polymorphic communication channel — phone, email, fax, url,
-      mail, etc. OCP: new channel kinds are added via the
+      mail, etc. `kind` discriminates the channel; `value` carries the
+      address/number; `label` is a free-form display hint ("Office",
+      "Front desk"). OCP: new channel kinds are added via the
       ContactMethodKind enum (or `other` + extensions).
     additionalProperties: false
     properties:
@@ -124,7 +126,8 @@ $defs:
     description: |
       Structured personal/organisational name (VCARD RFC 6350
       conventions). `formatted` is the pre-built display string (FN);
-      the structured components (N) are stored separately.
+      the structured components (N) are stored separately for sorting,
+      indexing, or locale-aware rendering.
     additionalProperties: false
     properties:
       formatted:  { type: string }
@@ -805,10 +808,9 @@ $defs:
   BodyVocabularyEntry:
     type: object
     description: |
-      One entry in a per-dataset body_vocabulary list (v2.1,
-      TODO.refactor/46). Maps a free-form body_type to a short
-      canonical value. SSOT for body_type -> canonical_type resolution
-      within the declaring collection.
+      One entry in a per-dataset body_vocabulary list. Maps a free-form
+      body_type to a short canonical value. SSOT for body_type ->
+      canonical_type resolution within the declaring collection.
     additionalProperties: false
     properties:
       body_type:      { type: string }


### PR DESCRIPTION
## Summary

Companion to edoxen/edoxen#29 (gem schema ↔ model canonical schema sync).

The canonical schema is the single source of truth that the gem mirrors. Three `$defs` in `meeting.yaml` had less informative descriptions than the gem's mirror:

- **BodyVocabularyEntry** — gem dropped the `(v2.1, TODO.refactor/46)` attribution that doesn't help wire consumers.
- **ContactMethod** — gem has an extra sentence clarifying that `kind` discriminates the channel, `value` carries the address, and `label` is a free-form display hint.
- **Name** — gem adds "for sorting, indexing, or locale-aware rendering" to explain why callers might prefer structured components over the pre-built `formatted` display string.

Pushed the gem versions up so the model stays canonical. The gem now has a sync spec (edoxen/edoxen#29) that enforces byte-for-byte equality on every `$defs` entry between the gem's mirror and this canonical schema; future drift will fail there.

## Test plan

- [x] The gem's new `schema_model_canonical_sync_spec.rb` (edoxen/edoxen#29) passes against this updated model.
- [x] No model-side specs (the model repo has no spec suite).
