### PR TITLE
feat(schema): allow MeetingSeries as a top-level document

### DIFF
--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -18,6 +18,7 @@ type: object
 oneOf:
   - $ref: "#/$defs/MeetingCollection"
   - $ref: "#/$defs/Meeting"
+  - $ref: "#/$defs/MeetingSeries"
 
 $defs:
 


### PR DESCRIPTION
## Summary

Adds MeetingSeries to the root `oneOf` of `schema/meeting.yaml` so the schema accepts a standalone MeetingSeries YAML file as a top-level document. MeetingSeries was previously only reachable as a `$ref` inside other documents.

Backwards-compatible: existing Meeting and MeetingCollection documents still validate unchanged.

**Why:** Downstream consumers (e.g. `isotc184sc4/resolutions-data`) want to ship a committee-level MeetingSeries fixture as the single source of truth for committee metadata — name, description, chair (as `contact`), secretariat (as `hosts[]`), social-media URLs (as `extensions[]`). Today those consumers hard-code committee metadata in browser source files; this PR enables a model-driven replacement.

Mirror PR: edoxen/edoxen-model#20.

## Test plan

- [x] `bundle exec rspec` — 1339 / 0 failures.
- [x] `bundle exec rubocop` — 0 offenses.
- [ ] (Post-merge) Release as 2.1.2; tc184sc4 PR consumes.
