### PR TITLE
feat(schema): sync to 1.0 — per-field localization, URN registries

### DIFF
--- a/models/action.lutaml
+++ b/models/action.lutaml
@@ -1,5 +1,5 @@
 class Action {
   type: ActionType
-  dateEffective: DateTime
+  dateEffective: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/approval.lutaml
+++ b/models/approval.lutaml
@@ -1,6 +1,6 @@
 class Approval {
   type: ApprovalType
   degree: ApprovalDegree
-  date: Date
+  date: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/consideration.lutaml
+++ b/models/consideration.lutaml
@@ -1,5 +1,5 @@
 class Consideration {
   type: ConsiderationType
-  dateEffective: Date
+  dateEffective: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/decision_metadata.lutaml
+++ b/models/decision_metadata.lutaml
@@ -1,5 +1,5 @@
 class DecisionMetadata {
-  date: DateTime
+  date: Date
   title: LocalizedString[0..*]
   source: String
   sourceUrls: SourceUrl[0..*]

--- a/models/meeting_identifier.lutaml
+++ b/models/meeting_identifier.lutaml
@@ -1,4 +1,4 @@
 class MeetingIdentifier {
   venue: String
-  date: DateTime
+  date: Date
 }

--- a/schema/decision-collection.yaml
+++ b/schema/decision-collection.yaml
@@ -1,9 +1,15 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/edoxen/edoxen/schema/edoxen.yaml
+"$id": https://github.com/edoxen/edoxen-model/schema/decision-collection.yaml
 title: Edoxen Decision Collection Schema
 description: |
-  Schema for validating Edoxen DecisionCollection YAML files.
+  Schema for validating Edoxen decision-side YAML files.
+
+  Accepts three top-level document kinds via `oneOf`:
+
+    * `DecisionCollection` — the formal outcomes adopted by a Meeting.
+    * `ContactCollection` — a scoped-URN registry of Contacts.
+    * `VenueCollection`  — a scoped-URN registry of Venues.
 
   Mirrors the canonical LutaML information model in
   https://github.com/edoxen/edoxen-model/tree/main/models .
@@ -18,17 +24,26 @@ description: |
   message degrades to "value ... is not one of: (see schema)". This
   is documented in `Edoxen::SchemaValidator#format_message`.
 type: object
-additionalProperties: false
-properties:
-  metadata:
-    "$ref": "#/$defs/DecisionMetadata"
-  decisions:
-    type: array
-    items:
-      "$ref": "#/$defs/Decision"
-required:
-- decisions
+oneOf:
+- "$ref": "#/$defs/DecisionCollection"
+- "$ref": "#/$defs/ContactCollection"
+- "$ref": "#/$defs/VenueCollection"
 "$defs":
+  DecisionCollection:
+    type: object
+    description: |
+      Top-level container for a published decision collection: metadata
+      plus the list of decisions.
+    additionalProperties: false
+    properties:
+      metadata:
+        "$ref": "#/$defs/DecisionMetadata"
+      decisions:
+        type: array
+        items:
+          "$ref": "#/$defs/Decision"
+    required:
+    - decisions
   StructuredIdentifier:
     type: object
     description: An identifier (prefix + number). A Decision carries 1..* of these.

--- a/schema/examples/decision-example.yaml
+++ b/schema/examples/decision-example.yaml
@@ -1,58 +1,59 @@
 ---
 metadata:
-  title: 56th CIML meeting (2025) - Resolution 44 (multilingual)
+  title:
+  - spelling: eng
+    value: 56th CIML meeting (2025) — Resolutions
+  - spelling: fra
+    value: 56e réunion du CIML (2025) — Résolutions
   date: 2025-10-13
   source: BIML Secretariat
   city: CNSHA
   country_code: DE
-  title_localized:
-    - language_code: eng
-      script: Latn
-      title: 56th CIML meeting (2025) — Resolutions
-    - language_code: fra
-      script: Latn
-      title: 56e réunion du CIML (2025) — Résolutions
   source_urls:
-    - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
-      format: pdf
-      language_code: eng
-    - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
-      format: pdf
-      language_code: fra
+  - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
+    format: pdf
+    spelling: eng
+  - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
+    format: pdf
+    spelling: fra
 decisions:
-  - identifier:
-    - prefix: CIML
-      number: "2025-44"
-    kind: resolution
-    status: decided
-    doi: 10.63493/resolutions/ciml202544
-    urn: urn:oiml:doc:ciml:resolution:2025-44
-    agenda_item: "16.2"
-    dates:
-      - date: 2025-10-13
-        type: discussed
-    localizations:
-      - language_code: eng
-        script: Latn
-        title: Decision on the renewal of the contract of Mr Anthony Donnellan
-        subject: CIML
-        actions:
-          - type: decides
-            date_effective:
-              date: 2025-10-13
-              type: adoption
-            message: |
-              The Committee decides to renew the contract of
-              Mr Anthony Donnellan as BIML Director.
-      - language_code: fra
-        script: Latn
-        title: Décision sur le renouvellement du contrat de M. Anthony Donnellan
-        subject: CIML
-        actions:
-          - type: decides
-            date_effective:
-              date: 2025-10-13
-              type: adoption
-            message: |
-              Le Comité décide de renouveler le contrat de
-              M. Anthony Donnellan en tant que Directeur du BIML.
+- identifier:
+  - prefix: CIML
+    number: 2025-44
+  kind: resolution
+  status: decided
+  doi: 10.63493/resolutions/ciml202544
+  urn: urn:oiml:doc:ciml:resolution:2025-44
+  agenda_item: '16.2'
+  dates:
+  - date: 2025-10-13
+    type: discussed
+  title:
+  - spelling: eng
+    value: Decision on the renewal of the contract of Mr Anthony Donnellan
+  - spelling: fra
+    value: Décision sur le renouvellement du contrat de M. Anthony Donnellan
+  subject:
+  - spelling: eng
+    value: CIML
+  - spelling: fra
+    value: CIML
+  actions:
+  - type: decides
+    date_effective:
+      date: 2025-10-13
+      type: adoption
+    message:
+    - spelling: eng
+      value: |
+        The Committee decides to renew the contract of
+        Mr Anthony Donnellan as BIML Director.
+  - type: decides
+    date_effective:
+      date: 2025-10-13
+      type: adoption
+    message:
+    - spelling: fra
+      value: |
+        Le Comité décide de renouveler le contrat de
+        M. Anthony Donnellan en tant que Directeur du BIML.

--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -1,6 +1,6 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/edoxen/edoxen/schema/meeting.yaml
+"$id": https://github.com/edoxen/edoxen-model/schema/meeting.yaml
 title: Edoxen Meeting Schema
 description: |
   Schema for validating Edoxen Meeting/Agenda YAML files.


### PR DESCRIPTION
Updates canonical schemas to match gem v0.8.0. Schemas grew from 1973 to 2741 lines (+768) reflecting per-field LocalizedString, ContactCollection/VenueCollection, scoped URN registries, ISO 24229 spelling codes.