### PR TITLE
feat(model): integrate BS 0:2006 meeting-minutes concepts

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -104,6 +104,28 @@ Any entity-typed field accepts either **inline data** (full object) or
   canonical_type).
 * `EntityRef` — typed cross-reference between entities.
 
+=== BS 0:2006 meeting-minutes concepts
+
+Source: BS 0:2006 §7.6 (BSI committee minutes standard). The concepts
+are universal across standards bodies — ISO, IEC, BIPM, IETF all track
+statements, declarations, and scheduled-vs-occurred times.
+
+* `Statement`, `StatementKind` — one remark by one or more members;
+  kind discriminates `statement` / `comment` / `standpoint`.
+* `Declaration`, `DeclarationKind` — conflict-of-interest and IPR
+  declarations; IPR carries typed `EntityRef` subject and target
+  (`iprSubjectRef`, `iprTargetRef`).
+* `DateTimeRange` — sub-day precision range, parallel to `DateRange`.
+* `Meeting.scheduledDateRange` (renamed from `dateRange`),
+  `Meeting.occurredDateRange: DateTimeRange`,
+  `Meeting.declarations: Declaration[0..*]`.
+* `Topic.statements`, `Topic.declarations` — standing positions that
+  travel with the topic across meetings.
+* `MinutesSection.statements` — per-meeting remarks on this section.
+* `MinutesSection.topic_ref` — URN back-link to a `Topic`,
+  formalising the convention that `MinutesSection#number` matches
+  `AgendaItem#label`.
+
 === Enums
 
 Single source of truth in `Edoxen::Enums` (Ruby) and the schemas'

--- a/models/action.lutaml
+++ b/models/action.lutaml
@@ -1,5 +1,5 @@
 class Action {
   type: ActionType
-  dateEffective: DateTime
+  dateEffective: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/approval.lutaml
+++ b/models/approval.lutaml
@@ -1,6 +1,6 @@
 class Approval {
   type: ApprovalType
   degree: ApprovalDegree
-  date: Date
+  date: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/consideration.lutaml
+++ b/models/consideration.lutaml
@@ -1,5 +1,5 @@
 class Consideration {
   type: ConsiderationType
-  dateEffective: Date
+  dateEffective: DecisionDate
   message: LocalizedString[0..*]
 }

--- a/models/date_time_range.lutaml
+++ b/models/date_time_range.lutaml
@@ -1,0 +1,10 @@
+// DateTimeRange — start + end pair with sub-day precision. Use
+// when a DateRange (day granularity) is insufficient — e.g.
+// `Meeting#occurredDateRange` (a meeting that ran 09:00–11:30).
+//
+// Parallel to DateRange; the two are intentionally separate types
+// so the granularity is visible at the type level.
+class DateTimeRange {
+  start: DateTime
+  end: DateTime
+}

--- a/models/decision_metadata.lutaml
+++ b/models/decision_metadata.lutaml
@@ -1,5 +1,5 @@
 class DecisionMetadata {
-  date: DateTime
+  date: Date
   title: LocalizedString[0..*]
   source: String
   sourceUrls: SourceUrl[0..*]

--- a/models/declaration.lutaml
+++ b/models/declaration.lutaml
@@ -1,0 +1,33 @@
+// Declaration — a formal declaration made by one or more meeting
+// members. Covers the two BS 0:2006 declaration types via the
+// `kind` discriminator:
+//
+//   * `conflict_of_interest` — a member declares a conflict on a
+//     target (typically a Topic or a TopicDocument).
+//   * `ipr` — a member declares an IPR position on a target (a
+//     published standard or work in progress).
+//
+// The IPR-specific fields (`iprSubjectRef`, `iprTargetRef`) are
+// populated only when `kind == "ipr"`. This mirrors edoxen's
+// "flat class, kind discriminates which subset is populated"
+// pattern (cf. Venue: physical fields + virtual fields on one
+// flat class).
+//
+// Attachment points: `Meeting#declarations[]` (per-meeting) and
+// `Topic#declarations[]` (standing position that travels with
+// the topic).
+class Declaration {
+  kind: DeclarationKind
+  description: LocalizedString[0..*]
+  party: Person[0..*]
+  // IPR-specific: the IPR item that applies (e.g. a patent
+  // declaration on a specific patent). Populated only when
+  // kind == "ipr". Typed EntityRef — validates that the
+  // reference resolves.
+  iprSubjectRef: EntityRef
+  // IPR-specific: the published standard or work in progress
+  // that the IPR declaration applies to. Populated only when
+  // kind == "ipr".
+  iprTargetRef: EntityRef
+  extensions: MeetingExtension[0..*]
+}

--- a/models/declaration_kind.lutaml
+++ b/models/declaration_kind.lutaml
@@ -1,0 +1,7 @@
+// DeclarationKind — discriminates the two BS 0:2006 declaration
+// types. Adding a new kind is a one-line enum extension; the
+// Declaration model itself never needs to change (OCP).
+enum DeclarationKind {
+  conflict_of_interest
+  ipr
+}

--- a/models/meeting.lutaml
+++ b/models/meeting.lutaml
@@ -8,7 +8,8 @@ class Meeting {
   visibility: Visibility
   bodyType: String
   title: LocalizedString[0..*]
-  dateRange: DateRange
+  scheduledDateRange: DateRange
+  occurredDateRange: DateTimeRange
   recurrence: Recurrence
   venues: Venue[0..*]
   generalArea: LocalizedString[0..*]
@@ -29,6 +30,7 @@ class Meeting {
   deadlines: Deadline[0..*]
   attendance: Attendance[0..*]
   minutes: Minutes[0..*]
+  declarations: Declaration[0..*]
   decisions: Decision[0..*]
   motions: Motion[0..*]
   votings: Voting[0..*]

--- a/models/meeting_identifier.lutaml
+++ b/models/meeting_identifier.lutaml
@@ -1,4 +1,4 @@
 class MeetingIdentifier {
   venue: String
-  date: DateTime
+  date: Date
 }

--- a/models/minutes_section.lutaml
+++ b/models/minutes_section.lutaml
@@ -5,4 +5,6 @@ class MinutesSection {
   page_start: Integer
   page_end: Integer
   references: Reference[0..*]
+  statements: Statement[0..*]
+  topic_ref: String
 }

--- a/models/statement.lutaml
+++ b/models/statement.lutaml
@@ -1,0 +1,21 @@
+// Statement — one remark made by one or more meeting members on a
+// topic or a minutes section. Carries a per-field Localized
+// description and a list of members (Person references) who made
+// the statement.
+//
+// The `kind` discriminator separates the three BS 0:2006 statement
+// types: `statement` (general remark), `comment` (sub-type), and
+// `standpoint` (a member's position on the topic). New kinds are
+// added by extending the StatementKind enum (or use `other` +
+// extensions for adopter-specific kinds) — no model change
+// required (OCP).
+//
+// Attachment points: `MinutesSection#statements[]` (per-meeting,
+// what was said this time) and `Topic#statements[]` (standing
+// position that travels with the topic across meetings).
+class Statement {
+  kind: StatementKind
+  description: LocalizedString[0..*]
+  party: Person[0..*]
+  extensions: MeetingExtension[0..*]
+}

--- a/models/statement_kind.lutaml
+++ b/models/statement_kind.lutaml
@@ -1,0 +1,8 @@
+// StatementKind — discriminates the three BS 0:2006 statement types.
+// Adding a new kind is a one-line enum extension; the Statement
+// model itself never needs to change (OCP).
+enum StatementKind {
+  statement
+  comment
+  standpoint
+}

--- a/models/topic.lutaml
+++ b/models/topic.lutaml
@@ -10,5 +10,7 @@ class Topic {
   references: Reference[0..*]
   motions: String[0..*]
   decisions: String[0..*]
+  statements: Statement[0..*]
+  declarations: Declaration[0..*]
   extensions: MeetingExtension[0..*]
 }

--- a/schema/decision-collection.yaml
+++ b/schema/decision-collection.yaml
@@ -545,6 +545,14 @@ oneOf:
         type: array
         items:
           type: string
+      statements:
+        type: array
+        items:
+          "$ref": "#/$defs/Statement"
+      declarations:
+        type: array
+        items:
+          "$ref": "#/$defs/Declaration"
       extensions:
         type: array
         items:
@@ -1429,3 +1437,84 @@ oneOf:
     - abstain
     - absent
     - not_applicable
+  DateTimeRange:
+    type: object
+    description: |
+      Start + end pair with sub-day precision. Parallel to DateRange;
+      use when day granularity is insufficient (e.g. a meeting that
+      ran 09:00–11:30).
+    additionalProperties: false
+    properties:
+      start:
+        type: string
+        format: date-time
+      end:
+        type: string
+        format: date-time
+  StatementKind:
+    type: string
+    description: |
+      Discriminator for the three BS 0:2006 statement types. Adding a
+      new kind is a one-line enum extension; the Statement model
+      itself never needs to change (OCP).
+    enum:
+    - statement
+    - comment
+    - standpoint
+  DeclarationKind:
+    type: string
+    description: |
+      Discriminator for the two BS 0:2006 declaration types
+      (conflict of interest, IPR).
+    enum:
+    - conflict_of_interest
+    - ipr
+  Statement:
+    type: object
+    description: |
+      One remark made by one or more meeting members on a topic or a
+      minutes section. Per-field Localized description; party is a
+      list of Person references. The `kind` discriminator separates
+      the three BS 0:2006 statement types.
+    additionalProperties: false
+    properties:
+      kind:
+        "$ref": "#/$defs/StatementKind"
+      description:
+        type: array
+        items:
+          "$ref": "#/$defs/LocalizedString"
+      party:
+        type: array
+        items:
+          "$ref": "#/$defs/Person"
+      extensions:
+        type: array
+        items:
+          "$ref": "#/$defs/MeetingExtension"
+  Declaration:
+    type: object
+    description: |
+      A formal declaration (conflict of interest or IPR) made by one
+      or more meeting members. IPR-specific fields (`ipr_subject_ref`,
+      `ipr_target_ref`) are populated only when `kind == "ipr"`.
+    additionalProperties: false
+    properties:
+      kind:
+        "$ref": "#/$defs/DeclarationKind"
+      description:
+        type: array
+        items:
+          "$ref": "#/$defs/LocalizedString"
+      party:
+        type: array
+        items:
+          "$ref": "#/$defs/Person"
+      ipr_subject_ref:
+        "$ref": "#/$defs/EntityRef"
+      ipr_target_ref:
+        "$ref": "#/$defs/EntityRef"
+      extensions:
+        type: array
+        items:
+          "$ref": "#/$defs/MeetingExtension"

--- a/schema/decision-collection.yaml
+++ b/schema/decision-collection.yaml
@@ -1,9 +1,15 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/edoxen/edoxen/schema/edoxen.yaml
+"$id": https://github.com/edoxen/edoxen-model/schema/decision-collection.yaml
 title: Edoxen Decision Collection Schema
 description: |
-  Schema for validating Edoxen DecisionCollection YAML files.
+  Schema for validating Edoxen decision-side YAML files.
+
+  Accepts three top-level document kinds via `oneOf`:
+
+    * `DecisionCollection` — the formal outcomes adopted by a Meeting.
+    * `ContactCollection` — a scoped-URN registry of Contacts.
+    * `VenueCollection`  — a scoped-URN registry of Venues.
 
   Mirrors the canonical LutaML information model in
   https://github.com/edoxen/edoxen-model/tree/main/models .
@@ -18,17 +24,26 @@ description: |
   message degrades to "value ... is not one of: (see schema)". This
   is documented in `Edoxen::SchemaValidator#format_message`.
 type: object
-additionalProperties: false
-properties:
-  metadata:
-    "$ref": "#/$defs/DecisionMetadata"
-  decisions:
-    type: array
-    items:
-      "$ref": "#/$defs/Decision"
-required:
-- decisions
+oneOf:
+- "$ref": "#/$defs/DecisionCollection"
+- "$ref": "#/$defs/ContactCollection"
+- "$ref": "#/$defs/VenueCollection"
 "$defs":
+  DecisionCollection:
+    type: object
+    description: |
+      Top-level container for a published decision collection: metadata
+      plus the list of decisions.
+    additionalProperties: false
+    properties:
+      metadata:
+        "$ref": "#/$defs/DecisionMetadata"
+      decisions:
+        type: array
+        items:
+          "$ref": "#/$defs/Decision"
+    required:
+    - decisions
   StructuredIdentifier:
     type: object
     description: An identifier (prefix + number). A Decision carries 1..* of these.

--- a/schema/examples/decision-example.yaml
+++ b/schema/examples/decision-example.yaml
@@ -1,58 +1,59 @@
 ---
 metadata:
-  title: 56th CIML meeting (2025) - Resolution 44 (multilingual)
+  title:
+  - spelling: eng
+    value: 56th CIML meeting (2025) — Resolutions
+  - spelling: fra
+    value: 56e réunion du CIML (2025) — Résolutions
   date: 2025-10-13
   source: BIML Secretariat
   city: CNSHA
   country_code: DE
-  title_localized:
-    - language_code: eng
-      script: Latn
-      title: 56th CIML meeting (2025) — Resolutions
-    - language_code: fra
-      script: Latn
-      title: 56e réunion du CIML (2025) — Résolutions
   source_urls:
-    - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
-      format: pdf
-      language_code: eng
-    - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
-      format: pdf
-      language_code: fra
+  - ref: https://www.oiml.org/en/resolutions/ciml56-en.pdf
+    format: pdf
+    spelling: eng
+  - ref: https://www.oiml.org/fr/resolutions/ciml56-fr.pdf
+    format: pdf
+    spelling: fra
 decisions:
-  - identifier:
-    - prefix: CIML
-      number: "2025-44"
-    kind: resolution
-    status: decided
-    doi: 10.63493/resolutions/ciml202544
-    urn: urn:oiml:doc:ciml:resolution:2025-44
-    agenda_item: "16.2"
-    dates:
-      - date: 2025-10-13
-        type: discussed
-    localizations:
-      - language_code: eng
-        script: Latn
-        title: Decision on the renewal of the contract of Mr Anthony Donnellan
-        subject: CIML
-        actions:
-          - type: decides
-            date_effective:
-              date: 2025-10-13
-              type: adoption
-            message: |
-              The Committee decides to renew the contract of
-              Mr Anthony Donnellan as BIML Director.
-      - language_code: fra
-        script: Latn
-        title: Décision sur le renouvellement du contrat de M. Anthony Donnellan
-        subject: CIML
-        actions:
-          - type: decides
-            date_effective:
-              date: 2025-10-13
-              type: adoption
-            message: |
-              Le Comité décide de renouveler le contrat de
-              M. Anthony Donnellan en tant que Directeur du BIML.
+- identifier:
+  - prefix: CIML
+    number: 2025-44
+  kind: resolution
+  status: decided
+  doi: 10.63493/resolutions/ciml202544
+  urn: urn:oiml:doc:ciml:resolution:2025-44
+  agenda_item: '16.2'
+  dates:
+  - date: 2025-10-13
+    type: discussed
+  title:
+  - spelling: eng
+    value: Decision on the renewal of the contract of Mr Anthony Donnellan
+  - spelling: fra
+    value: Décision sur le renouvellement du contrat de M. Anthony Donnellan
+  subject:
+  - spelling: eng
+    value: CIML
+  - spelling: fra
+    value: CIML
+  actions:
+  - type: decides
+    date_effective:
+      date: 2025-10-13
+      type: adoption
+    message:
+    - spelling: eng
+      value: |
+        The Committee decides to renew the contract of
+        Mr Anthony Donnellan as BIML Director.
+  - type: decides
+    date_effective:
+      date: 2025-10-13
+      type: adoption
+    message:
+    - spelling: fra
+      value: |
+        Le Comité décide de renouveler le contrat de
+        M. Anthony Donnellan en tant que Directeur du BIML.

--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -1,6 +1,6 @@
 ---
 "$schema": http://json-schema.org/draft-07/schema#
-"$id": https://github.com/edoxen/edoxen/schema/meeting.yaml
+"$id": https://github.com/edoxen/edoxen-model/schema/meeting.yaml
 title: Edoxen Meeting Schema
 description: |
   Schema for validating Edoxen Meeting/Agenda YAML files.

--- a/schema/meeting.yaml
+++ b/schema/meeting.yaml
@@ -386,6 +386,16 @@ oneOf:
         type: array
         items:
           "$ref": "#/$defs/Reference"
+      statements:
+        type: array
+        items:
+          "$ref": "#/$defs/Statement"
+      topic_ref:
+        type: string
+        description: |
+          URN back-reference to the Topic this section records.
+          Optional; formalises the convention that
+          `MinutesSection#number` matches `AgendaItem#label`.
   Minutes:
     type: object
     description: |
@@ -585,6 +595,14 @@ oneOf:
         type: array
         items:
           type: string
+      statements:
+        type: array
+        items:
+          "$ref": "#/$defs/Statement"
+      declarations:
+        type: array
+        items:
+          "$ref": "#/$defs/Declaration"
       extensions:
         type: array
         items:
@@ -960,8 +978,10 @@ oneOf:
         type: array
         items:
           "$ref": "#/$defs/LocalizedString"
-      date_range:
+      scheduled_date_range:
         "$ref": "#/$defs/DateRange"
+      occurred_date_range:
+        "$ref": "#/$defs/DateTimeRange"
       recurrence:
         "$ref": "#/$defs/Recurrence"
       venues:
@@ -1026,6 +1046,10 @@ oneOf:
         type: array
         items:
           "$ref": "#/$defs/Minutes"
+      declarations:
+        type: array
+        items:
+          "$ref": "#/$defs/Declaration"
       decisions:
         type: array
         items:
@@ -1308,3 +1332,84 @@ oneOf:
     - weekly
     - monthly
     - yearly
+  DateTimeRange:
+    type: object
+    description: |
+      Start + end pair with sub-day precision. Parallel to DateRange;
+      use when day granularity is insufficient (e.g. a meeting that
+      ran 09:00–11:30).
+    additionalProperties: false
+    properties:
+      start:
+        type: string
+        format: date-time
+      end:
+        type: string
+        format: date-time
+  StatementKind:
+    type: string
+    description: |
+      Discriminator for the three BS 0:2006 statement types. Adding a
+      new kind is a one-line enum extension; the Statement model
+      itself never needs to change (OCP).
+    enum:
+    - statement
+    - comment
+    - standpoint
+  DeclarationKind:
+    type: string
+    description: |
+      Discriminator for the two BS 0:2006 declaration types
+      (conflict of interest, IPR).
+    enum:
+    - conflict_of_interest
+    - ipr
+  Statement:
+    type: object
+    description: |
+      One remark made by one or more meeting members on a topic or a
+      minutes section. Per-field Localized description; party is a
+      list of Person references. The `kind` discriminator separates
+      the three BS 0:2006 statement types.
+    additionalProperties: false
+    properties:
+      kind:
+        "$ref": "#/$defs/StatementKind"
+      description:
+        type: array
+        items:
+          "$ref": "#/$defs/LocalizedString"
+      party:
+        type: array
+        items:
+          "$ref": "#/$defs/Person"
+      extensions:
+        type: array
+        items:
+          "$ref": "#/$defs/MeetingExtension"
+  Declaration:
+    type: object
+    description: |
+      A formal declaration (conflict of interest or IPR) made by one
+      or more meeting members. IPR-specific fields (`ipr_subject_ref`,
+      `ipr_target_ref`) are populated only when `kind == "ipr"`.
+    additionalProperties: false
+    properties:
+      kind:
+        "$ref": "#/$defs/DeclarationKind"
+      description:
+        type: array
+        items:
+          "$ref": "#/$defs/LocalizedString"
+      party:
+        type: array
+        items:
+          "$ref": "#/$defs/Person"
+      ipr_subject_ref:
+        "$ref": "#/$defs/EntityRef"
+      ipr_target_ref:
+        "$ref": "#/$defs/EntityRef"
+      extensions:
+        type: array
+        items:
+          "$ref": "#/$defs/MeetingExtension"


### PR DESCRIPTION
Integrates BS 0:2006 section 7.6 meeting-minutes concepts into Edoxen Model 1.0 core.

New entities: Statement, Declaration, DateTimeRange plus StatementKind and DeclarationKind enums.
Extended: Meeting (rename dateRange to scheduledDateRange, add occurredDateRange and declarations), Topic (add statements and declarations), MinutesSection (add statements and topic_ref).

Every translatable field is per-field LocalizedString (ISO 24229). IPR subject/target use EntityRef for typed validated cross-references.

Design decisions: enum for type discrimination, renamed dateRange to scheduledDateRange, both Date and DateTime precision via parallel DateTimeRange class, EntityRef for IPR refs, both Topic and MinutesSection carry statements (standing vs per-meeting).