### PR TITLE
fix(model): Meeting.decisions is StructuredIdentifier[] (refs), not Decision[]

### DIFF
--- a/models/meeting.lutaml
+++ b/models/meeting.lutaml
@@ -33,7 +33,7 @@ class Meeting {
   attendance: Attendance[0..*]
   minutes: Minutes[0..*]
   declarations: Declaration[0..*]
-  decisions: Decision[0..*]
+  decisions: StructuredIdentifier[0..*]
   motions: Motion[0..*]
   votings: Voting[0..*]
   relations: MeetingRelation[0..*]


### PR DESCRIPTION
The JSON schema (schema/meeting.yaml) has always said `items: {$ref: StructuredIdentifier}`, and every consumer dataset (tc154, tc184sc4, oiml) references decisions by prefix+number from their DecisionCollections. The lutaml attribute drifted to `Decision[0..*]` during the BS 0 minutes work. Align with the schema and actual usage; embedded decisions remain expressible inside minutes/decision-side documents.